### PR TITLE
#525 Replace Asciidoctor::convert() and OptionsBuilder::options() dep…

### DIFF
--- a/src/main/java/org/owasp/wrongsecrets/asciidoc/AsciiDocGenerator.java
+++ b/src/main/java/org/owasp/wrongsecrets/asciidoc/AsciiDocGenerator.java
@@ -1,12 +1,12 @@
 package org.owasp.wrongsecrets.asciidoc;
 
 import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Options;
 import org.springframework.core.io.ClassPathResource;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
-import java.util.Map;
 
 import static org.asciidoctor.Asciidoctor.Factory.create;
 
@@ -19,7 +19,7 @@ public class AsciiDocGenerator implements TemplateGenerator {
         var templateFile = name + ".adoc";
         try (var is = new ClassPathResource(templateFile).getInputStream()) {
             var writer = new StringWriter();
-            asciidoctor.convert(new InputStreamReader(is), writer, Map.of());
+            asciidoctor.convert(new InputStreamReader(is), writer, Options.builder().build());
             return writer.toString();
         }
     }

--- a/src/main/java/org/owasp/wrongsecrets/challenges/ChallengesAPIController.java
+++ b/src/main/java/org/owasp/wrongsecrets/challenges/ChallengesAPIController.java
@@ -4,7 +4,7 @@ import com.nimbusds.jose.shaded.json.JSONArray;
 import com.nimbusds.jose.shaded.json.JSONObject;
 import lombok.extern.slf4j.Slf4j;
 import org.asciidoctor.Asciidoctor;
-import org.asciidoctor.OptionsBuilder;
+import org.asciidoctor.Options;
 import org.owasp.wrongsecrets.RuntimeEnvironment;
 import org.owasp.wrongsecrets.ScoreCard;
 import org.owasp.wrongsecrets.asciidoc.TemplateGenerator;
@@ -90,10 +90,10 @@ public class ChallengesAPIController {
                 descriptions.add(description);
             } catch (IOException e) {
                 String rawHint = extractResource("classpath:explanations/" + challengeUI.getExplanation() + "_hint.adoc");
-                String hint = Asciidoctor.Factory.create().convert(rawHint, OptionsBuilder.options().build());
+                String hint = Asciidoctor.Factory.create().convert(rawHint, Options.builder().build());
                 hints.add(hint);
                 String rawDescription = extractResource("classpath:explanations/" + challengeUI.getExplanation() + ".adoc");
-                String description = Asciidoctor.Factory.create().convert(rawDescription, OptionsBuilder.options().build());
+                String description = Asciidoctor.Factory.create().convert(rawDescription, Options.builder().build());
                 descriptions.add(description);
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
Fix #525 

This change replace the usage of `Asciidoctor::convert()`  and `OptionsBuilder::options()` deprecated methods by the usage of `Options::builder()`.