### PR TITLE
Spring Security 5.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.5</version>
+        <version>2.7.6</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>org.owasp</groupId>
@@ -56,7 +56,7 @@
         <thymeleaf.version>3.0.15.RELEASE</thymeleaf.version>
         <thymeleaf.layout>3.1.0</thymeleaf.layout>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-        <spring.security.version>5.7.5</spring.security.version>
+        <spring-security.version>5.8.0</spring-security.version>
         <com.azure.spring.version>4.4.1</com.azure.spring.version>
         <cyclonedx.core.version>7.2.0</cyclonedx.core.version>
         <KeePassJava2.version>2.1.4</KeePassJava2.version>
@@ -92,17 +92,17 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-config</artifactId>
-            <version>${spring.security.version}</version>
+            <version>${spring-security.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-web</artifactId>
-            <version>${spring.security.version}</version>
+            <version>${spring-security.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
-            <version>${spring.security.version}</version>
+            <version>${spring-security.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/owasp/wrongsecrets/ActuatorSecurityConfiguration.java
+++ b/src/main/java/org/owasp/wrongsecrets/ActuatorSecurityConfiguration.java
@@ -12,7 +12,7 @@ public class ActuatorSecurityConfiguration {
     @Bean
     @Order(2)
     public SecurityFilterChain configureActuatorSecurity(HttpSecurity http) throws Exception {
-        http.requestMatcher(r ->
+        http.securityMatcher(r ->
                 r.getRequestURL().toString().contains("/actuator/health"))
             .csrf().disable();
         return http.build();

--- a/src/main/java/org/owasp/wrongsecrets/canaries/TokenCallbackSecurityConfiguration.java
+++ b/src/main/java/org/owasp/wrongsecrets/canaries/TokenCallbackSecurityConfiguration.java
@@ -4,15 +4,15 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 public class TokenCallbackSecurityConfiguration {
 
     @Bean
     @Order(0)
-    public DefaultSecurityFilterChain configureTokenCallbackSecurity(HttpSecurity http) throws Exception {
-        http.requestMatcher(r ->
+    public SecurityFilterChain configureTokenCallbackSecurity(HttpSecurity http) throws Exception {
+        http.securityMatcher(r ->
                 r.getRequestURL().toString().contains("canaries") || r.getRequestURL().toString().contains("token"))
             .csrf().disable();
         return http.build();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -69,6 +69,7 @@ spring.cloud.vault.kubernetes.service-account-token-file=/var/run/secrets/kubern
 spring.config.activate.on-profile=local
 challengedockermtpath=./
 asciidoctor.enabled=true
+spring.cloud.vault.enabled=false
 #---
 spring.config.activate.on-profile=local-vault
 wrongsecretvalue=wrongsecret


### PR DESCRIPTION
[Preparing for 6.0](https://docs.spring.io/spring-security/reference/5.8/migration/index.html)

> The Spring Security team has prepared the 5.8 release to simplify upgrading to Spring Security 6.0. Use 
> 5.8 and the steps below to minimize changes when [updating to 
> 6.0](https://docs.spring.io/spring-security/reference/migration/index.html) .

Blocks: #514 and #512 
