### PR TITLE
Fixing bootstrap application by removing PortMapper from production configuration

### DIFF
--- a/src/main/java/org/owasp/wrongsecrets/HerokuWebSecurityConfig.java
+++ b/src/main/java/org/owasp/wrongsecrets/HerokuWebSecurityConfig.java
@@ -14,7 +14,6 @@ public class HerokuWebSecurityConfig {
     @Bean
     @Order(1)
     public SecurityFilterChain configureHerokuWebSecurity(HttpSecurity http, ObjectProvider<PortMapper> portMapper) throws Exception {
-        portMapper.ifAvailable(http.portMapper()::portMapper);
         http.requiresChannel()
             .requestMatchers(r ->
                 r.getRequestURL().toString().contains("heroku")

--- a/src/test/java/org/owasp/wrongsecrets/ChallengeAPiControllerTest.java
+++ b/src/test/java/org/owasp/wrongsecrets/ChallengeAPiControllerTest.java
@@ -3,9 +3,8 @@ package org.owasp.wrongsecrets;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.context.annotation.Import;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.client.RestClientResponseException;
 
@@ -13,7 +12,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Import(ConventionPortMapper.class)
 class ChallengeAPiControllerTest {
     @LocalServerPort
     private int port;
@@ -28,14 +26,14 @@ class ChallengeAPiControllerTest {
     void shouldGetListOfChallenges() {
         var restTemplate = builder.build();
 
-        var callbackAdress = "http://localhost:"+port+"/api/Challenges";
+        var callbackAdress = "http://localhost:" + port + "/api/Challenges";
 
         try {
             var response = restTemplate.getForEntity(callbackAdress, String.class);
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
             assertThat(response.getBody()).contains("hint");
         } catch (RestClientResponseException e) {
-           fail(e);
+            fail(e);
         }
     }
 }

--- a/src/test/java/org/owasp/wrongsecrets/ChallengeUILimittedTest.java
+++ b/src/test/java/org/owasp/wrongsecrets/ChallengeUILimittedTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -21,7 +20,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     classes = WrongSecretsApplication.class
 )
 @AutoConfigureMockMvc
-@Import(ConventionPortMapper.class)
 class ChallengeUILimittedTest {
     @Autowired
     private MockMvc mvc;

--- a/src/test/java/org/owasp/wrongsecrets/HerokuWebSecurityConfigTest.java
+++ b/src/test/java/org/owasp/wrongsecrets/HerokuWebSecurityConfigTest.java
@@ -13,7 +13,7 @@ import org.springframework.web.client.ResourceAccessException;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Import(ConventionPortMapper.class)
+@Import({ConventionPortMapper.class, PortConfiguration.class})
 class HerokuWebSecurityConfigTest {
 
     @LocalServerPort

--- a/src/test/java/org/owasp/wrongsecrets/PortConfiguration.java
+++ b/src/test/java/org/owasp/wrongsecrets/PortConfiguration.java
@@ -1,19 +1,19 @@
 package org.owasp.wrongsecrets;
 
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.PortMapper;
 import org.springframework.security.web.SecurityFilterChain;
 
-@Configuration
+@TestConfiguration
 public class PortConfiguration {
     @Bean
     @Order(1)
     public SecurityFilterChain configureHerokuWebSecurityTest(HttpSecurity http,
-                                                          ObjectProvider<PortMapper> portMapper) throws Exception {
+                                                              ObjectProvider<PortMapper> portMapper) throws Exception {
         portMapper.ifAvailable(http.portMapper()::portMapper);
         http.requiresChannel()
             .requestMatchers(r ->

--- a/src/test/java/org/owasp/wrongsecrets/SecretLeakageControllerTest.java
+++ b/src/test/java/org/owasp/wrongsecrets/SecretLeakageControllerTest.java
@@ -10,7 +10,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
@@ -27,7 +26,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 @ExtendWith({SpringExtension.class})
 @ActiveProfiles("test")
 @AutoConfigureWebTestClient
-@Import(ConventionPortMapper.class)
 class SecretLeakageControllerTest {
 
     @Autowired

--- a/src/test/java/org/owasp/wrongsecrets/SecretsErrorControllerTest.java
+++ b/src/test/java/org/owasp/wrongsecrets/SecretsErrorControllerTest.java
@@ -3,16 +3,14 @@ package org.owasp.wrongsecrets;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.context.annotation.Import;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.web.client.RestClientResponseException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Import(ConventionPortMapper.class)
 class SecretsErrorControllerTest {
 
     @LocalServerPort

--- a/src/test/java/org/owasp/wrongsecrets/StartupListenerSuccessTest.java
+++ b/src/test/java/org/owasp/wrongsecrets/StartupListenerSuccessTest.java
@@ -8,12 +8,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.context.annotation.Import;
 
 @SpringBootTest(
     properties = { "spring.application.name=example", "K8S_ENV=DOCKER" }
 )
-@Import(ConventionPortMapper.class)
 class StartupListenerSuccessTest {
 
     @Autowired

--- a/src/test/java/org/owasp/wrongsecrets/canaries/CanaryCallbackTest.java
+++ b/src/test/java/org/owasp/wrongsecrets/canaries/CanaryCallbackTest.java
@@ -1,12 +1,10 @@
 package org.owasp.wrongsecrets.canaries;
 
 import org.junit.jupiter.api.Test;
-import org.owasp.wrongsecrets.ConventionPortMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.client.RestClientResponseException;
 
@@ -14,7 +12,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Import(ConventionPortMapper.class)
 class CanaryCallbackTest {
     @LocalServerPort
     private int port;

--- a/src/test/java/org/owasp/wrongsecrets/ctftests/ChallengesControllerCTFClientModeTest.java
+++ b/src/test/java/org/owasp/wrongsecrets/ctftests/ChallengesControllerCTFClientModeTest.java
@@ -2,14 +2,12 @@ package org.owasp.wrongsecrets.ctftests;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.owasp.wrongsecrets.ConventionPortMapper;
 import org.owasp.wrongsecrets.InMemoryScoreCard;
 import org.owasp.wrongsecrets.WrongSecretsApplication;
 import org.owasp.wrongsecrets.challenges.docker.Challenge1;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
@@ -28,7 +26,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     classes = WrongSecretsApplication.class
 )
 @AutoConfigureMockMvc
-@Import(ConventionPortMapper.class)
 class ChallengesControllerCTFClientModeTest {
 
     @Autowired

--- a/src/test/java/org/owasp/wrongsecrets/ctftests/ChallengesControllerCTFModeTest.java
+++ b/src/test/java/org/owasp/wrongsecrets/ctftests/ChallengesControllerCTFModeTest.java
@@ -2,14 +2,12 @@ package org.owasp.wrongsecrets.ctftests;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.owasp.wrongsecrets.ConventionPortMapper;
 import org.owasp.wrongsecrets.InMemoryScoreCard;
 import org.owasp.wrongsecrets.WrongSecretsApplication;
 import org.owasp.wrongsecrets.challenges.docker.Challenge1;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
@@ -28,7 +26,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     classes = WrongSecretsApplication.class
 )
 @AutoConfigureMockMvc
-@Import(ConventionPortMapper.class)
 class ChallengesControllerCTFModeTest {
 
     @Autowired

--- a/src/test/java/org/owasp/wrongsecrets/ctftests/ChallengesControllerCTFModeWithPresetCloudValuesTest.java
+++ b/src/test/java/org/owasp/wrongsecrets/ctftests/ChallengesControllerCTFModeWithPresetCloudValuesTest.java
@@ -2,7 +2,6 @@ package org.owasp.wrongsecrets.ctftests;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.owasp.wrongsecrets.ConventionPortMapper;
 import org.owasp.wrongsecrets.InMemoryScoreCard;
 import org.owasp.wrongsecrets.RuntimeEnvironment;
 import org.owasp.wrongsecrets.WrongSecretsApplication;
@@ -12,7 +11,6 @@ import org.owasp.wrongsecrets.challenges.cloud.Challenge9;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
@@ -33,7 +31,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     classes = WrongSecretsApplication.class
 )
 @AutoConfigureMockMvc
-@Import(ConventionPortMapper.class)
 class ChallengesControllerCTFModeWithPresetCloudValuesTest {
 
     @Autowired

--- a/src/test/java/org/owasp/wrongsecrets/ctftests/ChallengesControllerCTFModeWithPresetK8sAndVaultValuesTest.java
+++ b/src/test/java/org/owasp/wrongsecrets/ctftests/ChallengesControllerCTFModeWithPresetK8sAndVaultValuesTest.java
@@ -2,7 +2,6 @@ package org.owasp.wrongsecrets.ctftests;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.owasp.wrongsecrets.ConventionPortMapper;
 import org.owasp.wrongsecrets.InMemoryScoreCard;
 import org.owasp.wrongsecrets.WrongSecretsApplication;
 import org.owasp.wrongsecrets.challenges.kubernetes.Challenge5;
@@ -11,7 +10,6 @@ import org.owasp.wrongsecrets.challenges.kubernetes.Challenge7;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
@@ -29,7 +27,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     classes = WrongSecretsApplication.class
 )
 @AutoConfigureMockMvc
-@Import(ConventionPortMapper.class)
 class ChallengesControllerCTFModeWithPresetK8sAndVaultValuesTest {
 
     @Autowired

--- a/src/test/java/org/owasp/wrongsecrets/ctftests/ChallengesControllerCTFModeWithPresetK8sNoVaultValuesTest.java
+++ b/src/test/java/org/owasp/wrongsecrets/ctftests/ChallengesControllerCTFModeWithPresetK8sNoVaultValuesTest.java
@@ -2,7 +2,6 @@ package org.owasp.wrongsecrets.ctftests;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.owasp.wrongsecrets.ConventionPortMapper;
 import org.owasp.wrongsecrets.InMemoryScoreCard;
 import org.owasp.wrongsecrets.WrongSecretsApplication;
 import org.owasp.wrongsecrets.challenges.kubernetes.Challenge5;
@@ -11,7 +10,6 @@ import org.owasp.wrongsecrets.challenges.kubernetes.Challenge7;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
@@ -29,7 +27,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     classes = WrongSecretsApplication.class
 )
 @AutoConfigureMockMvc
-@Import(ConventionPortMapper.class)
 class ChallengesControllerCTFModeWithPresetK8sNoVaultValuesTest {
 
     @Autowired

--- a/src/test/java/org/owasp/wrongsecrets/oauth/TokenControllerTest.java
+++ b/src/test/java/org/owasp/wrongsecrets/oauth/TokenControllerTest.java
@@ -1,11 +1,9 @@
 package org.owasp.wrongsecrets.oauth;
 
 import org.junit.jupiter.api.Test;
-import org.owasp.wrongsecrets.ConventionPortMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -15,7 +13,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @AutoConfigureMockMvc
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Import(ConventionPortMapper.class)
 class TokenControllerTest {
 
     @Autowired


### PR DESCRIPTION
Unintentionally, in the previous PR https://github.com/OWASP/wrongsecrets/pull/570 `PortMapper` configuration was added into `src/main/java/org/owasp/wrongsecrets/HerokuWebSecurityConfig.java`. PortMapper configuration should be only in the `test` folder. In our case implemented in `src/test/java/org/owasp/wrongsecrets/PortConfiguration.java`. Moreover, I clean up not required `@Import(ConventionPortMapper.class)`