### PR TITLE
Feat: initial start with k8s 1.25 migration

### DIFF
--- a/.github/workflows/minikube-k8s-test.yml
+++ b/.github/workflows/minikube-k8s-test.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           minikube-version: 1.28.0
           driver: docker
-          kubernetes-version: v1.23.12
+          kubernetes-version: v1.25
       - name: test script
         run: |
           kubectl apply -f k8s/secrets-config.yml

--- a/.github/workflows/minikube-vault-test.yml
+++ b/.github/workflows/minikube-vault-test.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           minikube-version: 1.28.0
           driver: docker
-          kubernetes-version: v1.23.12
+          kubernetes-version: v1.25
       - name: Setup helm
         uses: azure/setup-helm@v3.5
         id: install

--- a/aws/README.md
+++ b/aws/README.md
@@ -111,9 +111,9 @@ The documentation below is auto-generated to give insight on what's created via 
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.53.0 |
-| <a name="provider_http"></a> [http](#provider\_http) | ~> 3.2.1 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.4.3 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.53.0 |
+| <a name="provider_http"></a> [http](#provider\_http) | 3.2.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
 
 ## Modules
 
@@ -154,7 +154,7 @@ The documentation below is auto-generated to give insight on what's created via 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The EKS cluster name | `string` | `"wrongsecrets-exercise-cluster"` | no |
-| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | The EKS cluster version to use | `string` | `"1.23"` | no |
+| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | The EKS cluster version to use | `string` | `"1.25"` | no |
 | <a name="input_region"></a> [region](#input\_region) | The AWS region to use | `string` | `"eu-west-1"` | no |
 
 ## Outputs

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -7,7 +7,7 @@ variable "region" {
 variable "cluster_version" {
   description = "The EKS cluster version to use"
   type        = string
-  default     = "1.23"
+  default     = "1.25"
 }
 
 variable "cluster_name" {

--- a/azure/README.md
+++ b/azure/README.md
@@ -106,9 +106,9 @@ The documentation below is auto-generated to give insight on what's created via 
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.42.0 |
-| <a name="provider_http"></a> [http](#provider\_http) | ~> 3.2.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.4.3 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.42.0 |
+| <a name="provider_http"></a> [http](#provider\_http) | 3.2.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
 
 ## Modules
 
@@ -143,7 +143,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The AKS cluster name | `string` | `"wrongsecrets-exercise-cluster"` | no |
-| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | The AKS cluster version to use | `string` | `"1.23.12"` | no |
+| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | The AKS cluster version to use | `string` | `"1.25"` | no |
 | <a name="input_region"></a> [region](#input\_region) | The Azure region to use | `string` | `"East US"` | no |
 
 ## Outputs

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -7,7 +7,7 @@ variable "region" {
 variable "cluster_version" {
   description = "The AKS cluster version to use"
   type        = string
-  default     = "1.23.12"
+  default     = "1.25"
 }
 
 variable "cluster_name" {

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -105,10 +105,10 @@ The documentation below is auto-generated to give insight on what's created via 
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 4.52.0 |
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | ~> 4.52.0 |
-| <a name="provider_http"></a> [http](#provider\_http) | ~> 3.2.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.4.3 |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.52.0 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | 4.52.0 |
+| <a name="provider_http"></a> [http](#provider\_http) | 3.2.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
 
 ## Modules
 
@@ -144,7 +144,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The GKE cluster name | `string` | `"wrongsecrets-exercise-cluster"` | no |
-| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | The GKE cluster version to use | `string` | `"1.23"` | no |
+| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | The GKE cluster version to use | `string` | `"1.25"` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | project id | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The GCP region to use | `string` | `"eu-west4"` | no |
 

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -12,7 +12,7 @@ variable "project_id" {
 variable "cluster_version" {
   description = "The GKE cluster version to use"
   type        = string
-  default     = "1.23"
+  default     = "1.25"
 }
 
 variable "cluster_name" {


### PR DESCRIPTION
Thank you for submitting a pull request to the WrongSecrets app!

What kind of changes does this PR include?

-   [x] Fixes or refactors
-   [ ] A new challenge
-   [ ] Additional documentation
-   [x] Something else : migration from 1.22 to K8s 1.25

Checklist:

-   [x] All the contributions made are solely the work of me and my co-authors
-   [ ] I tested the changes in this PR (if applicable)
-   [ ] I added unit tests to ensure my change works (when change in Java or on front-end code)
-   [ ] The PR passes pre-commit hooks and automated tests
-   [ ] Complete migration to K8s 1.25: Configure [PSA](https://kubernetes.io/docs/concepts/security/pod-security-admission/) and [PSS](https://kubernetes.io/docs/concepts/security/pod-security-standards/) and securitycontexts for all pods in
    - [ ] Azure 
    - [ ] AWS (https://aws.amazon.com/blogs/containers/implementing-pod-security-standards-in-amazon-eks/ & https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html ) 
    - [ ] GCP
    - [ ] Okteto config
    - [ ] Kubernetes deployment files
