### PR TITLE
feat(#692): Challenge 34 with a focus on determenistic use of KDFs

### DIFF
--- a/src/main/java/org/owasp/wrongsecrets/challenges/docker/Challenge34.java
+++ b/src/main/java/org/owasp/wrongsecrets/challenges/docker/Challenge34.java
@@ -1,8 +1,7 @@
 package org.owasp.wrongsecrets.challenges.docker;
 
-import java.util.List;
-
 import com.google.common.base.Strings;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.owasp.wrongsecrets.RuntimeEnvironment;
 import org.owasp.wrongsecrets.ScoreCard;
@@ -15,8 +14,8 @@ import org.springframework.security.crypto.password.Pbkdf2PasswordEncoder;
 import org.springframework.stereotype.Component;
 
 /**
- * This is a challenge based on the belief that a static string processed by Pbkdf2 can lead to a seecure setup.
- * <a href="https://www.dcode.fr/pbkdf2-hash">online generator</a>
+ * This is a challenge based on the belief that a static string processed by Pbkdf2 can lead to a
+ * seecure setup. <a href="https://www.dcode.fr/pbkdf2-hash">online generator</a>
  */
 @Slf4j
 @Component
@@ -66,21 +65,27 @@ public class Challenge34 extends Challenge {
     return List.of(RuntimeEnvironment.Environment.DOCKER);
   }
 
-  private String getKey(){
-      if (Strings.isNullOrEmpty(key)){
-          key = generateKey();
-      }
-      log.info("The key for challenge34 has been initialized, now you can use it for encryption when needed.");
-      return key;
+  private String getKey() {
+    if (Strings.isNullOrEmpty(key)) {
+      key = generateKey();
+    }
+    log.info(
+        "The key for challenge34 has been initialized, now you can use it for encryption when"
+            + " needed.");
+    return key;
   }
-  private String generateKey() {
-      String encryptedKey = "123%78___+WEssweLKWEJROUVHLAMW,NERO";
-      // note the static salt in use to get to the same key. otherwise the key is not reusable.
-      Pbkdf2PasswordEncoder encoder = new Pbkdf2PasswordEncoder("secret_salt", 0, 100000, Pbkdf2PasswordEncoder.SecretKeyFactoryAlgorithm.PBKDF2WithHmacSHA256);
-      encoder.setEncodeHashAsBase64(true);
 
-      return encoder.encode(encryptedKey);
+  private String generateKey() {
+    String encryptedKey = "123%78___+WEssweLKWEJROUVHLAMW,NERO";
+    // note the static salt in use to get to the same key. otherwise the key is not reusable.
+    Pbkdf2PasswordEncoder encoder =
+        new Pbkdf2PasswordEncoder(
+            "secret_salt",
+            0,
+            100000,
+            Pbkdf2PasswordEncoder.SecretKeyFactoryAlgorithm.PBKDF2WithHmacSHA256);
+    encoder.setEncodeHashAsBase64(true);
+
+    return encoder.encode(encryptedKey);
   }
 }
-
-

--- a/src/main/java/org/owasp/wrongsecrets/challenges/docker/Challenge34.java
+++ b/src/main/java/org/owasp/wrongsecrets/challenges/docker/Challenge34.java
@@ -1,0 +1,86 @@
+package org.owasp.wrongsecrets.challenges.docker;
+
+import java.util.List;
+
+import com.google.common.base.Strings;
+import lombok.extern.slf4j.Slf4j;
+import org.owasp.wrongsecrets.RuntimeEnvironment;
+import org.owasp.wrongsecrets.ScoreCard;
+import org.owasp.wrongsecrets.challenges.Challenge;
+import org.owasp.wrongsecrets.challenges.ChallengeTechnology;
+import org.owasp.wrongsecrets.challenges.Difficulty;
+import org.owasp.wrongsecrets.challenges.Spoiler;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.crypto.password.Pbkdf2PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+/**
+ * This is a challenge based on the belief that a static string processed by Pbkdf2 can lead to a seecure setup.
+ * <a href="https://www.dcode.fr/pbkdf2-hash">online generator</a>
+ */
+@Slf4j
+@Component
+@Order(34)
+public class Challenge34 extends Challenge {
+
+  private String key;
+
+  public Challenge34(ScoreCard scoreCard) {
+    super(scoreCard);
+  }
+
+  @Override
+  public boolean canRunInCTFMode() {
+    return true;
+  }
+
+  @Override
+  public Spoiler spoiler() {
+    return new Spoiler(getKey());
+  }
+
+  @Override
+  public boolean answerCorrect(String answer) {
+    return getKey().equals(answer);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public int difficulty() {
+    return Difficulty.NORMAL;
+  }
+
+  /** {@inheritDoc} This is a crypto (hashing) type of challenge */
+  @Override
+  public String getTech() {
+    return ChallengeTechnology.Tech.CRYPTOGRAPHY.id;
+  }
+
+  @Override
+  public boolean isLimitedWhenOnlineHosted() {
+    return false;
+  }
+
+  @Override
+  public List<RuntimeEnvironment.Environment> supportedRuntimeEnvironments() {
+    return List.of(RuntimeEnvironment.Environment.DOCKER);
+  }
+
+  private String getKey(){
+      if (Strings.isNullOrEmpty(key)){
+          key = generateKey();
+      }
+      log.info("The key for challenge34 has been initialized, now you can use it for encryption when needed.");
+      return key;
+  }
+  private String generateKey() {
+      String encryptedKey = "123%78___+WEssweLKWEJROUVHLAMW,NERO";
+      // note the static salt in use to get to the same key. otherwise the key is not reusable.
+      Pbkdf2PasswordEncoder encoder = new Pbkdf2PasswordEncoder("secret_salt", 0, 100000, Pbkdf2PasswordEncoder.SecretKeyFactoryAlgorithm.PBKDF2WithHmacSHA256);
+      encoder.setEncodeHashAsBase64(true);
+
+      return encoder.encode(encryptedKey);
+  }
+}
+
+

--- a/src/main/resources/explanations/challenge34.adoc
+++ b/src/main/resources/explanations/challenge34.adoc
@@ -1,4 +1,4 @@
 === Generating Random Keys
 
-Many security folks teach engineers to use secure key derivation functions like https://en.wikipedia.org/wiki/PBKDF2[PBKDF2] when a key needs to be generated. So a developer followed this instruction and tried to create a key in `Challenge33.java` which should now be far more secured than a hardcoded key.
-Can you spot the mistake made? Can you find the actual value of the generated key?
+Many security folks teach engineers to use secure key derivation functions like https://en.wikipedia.org/wiki/PBKDF2[PBKDF2] when a key needs to be generated. A developer followed this instruction and tried to create a key in `Challenge33.java`, which should now be far more secure than a hardcoded key.
+Can you spot the mistake? Can you find the value of the generated key?

--- a/src/main/resources/explanations/challenge34.adoc
+++ b/src/main/resources/explanations/challenge34.adoc
@@ -1,0 +1,4 @@
+=== Generating Random Keys
+
+Many security folks teach engineers to use secure key derivation functions like https://en.wikipedia.org/wiki/PBKDF2[PBKDF2] when a key needs to be generated. So a developer followed this instruction and tried to create a key in `Challenge33.java` which should now be far more secured than a hardcoded key.
+Can you spot the mistake made? Can you find the actual value of the generated key?

--- a/src/main/resources/explanations/challenge34_hint.adoc
+++ b/src/main/resources/explanations/challenge34_hint.adoc
@@ -2,4 +2,4 @@ This challenge can be solved by replaying the Key derivation function with the g
 1. Run the function online
 - Locate the parameters used for the key derivation function in the `generateKey` function in Challenge33.java
 - Copy the used parameters to an online https://www.dcode.fr/pbkdf2-hash[generator] and execute it
-- The website will return the value of the actual key.
+- The website will return the value of the key.

--- a/src/main/resources/explanations/challenge34_hint.adoc
+++ b/src/main/resources/explanations/challenge34_hint.adoc
@@ -1,0 +1,5 @@
+This challenge can be solved by replaying the Key derivation function with the given inputs.
+1. Run the function online
+- Locate the parameters used for the key derivation function in the `generateKey` function in Challenge33.java
+- Copy the used parameters to an online https://www.dcode.fr/pbkdf2-hash[generator] and execute it
+- The website will return the value of the actual key.

--- a/src/main/resources/explanations/challenge34_reason.adoc
+++ b/src/main/resources/explanations/challenge34_reason.adoc
@@ -1,3 +1,5 @@
 *Why Key Derivation Functions are not safe when using hardcoded values*
 
-TBD
+Key Derivation Functions (KDFs) are deterministic in nature. This means that for a given input, they will always give back the same output. So, if the parameters are hardcoded in code, anyone with access to the code can run the KDF with the coded parameters and get the actual key.
+
+KDFs should be used to generate keys based on dynamic input, such as human supplied passwords for instance. KDFs might be used in situations where secure random sources generate certain output which can be used to generate keys. Again, in both cases: the KDF its input is not hardcoded/deterministic. 

--- a/src/main/resources/explanations/challenge34_reason.adoc
+++ b/src/main/resources/explanations/challenge34_reason.adoc
@@ -1,5 +1,5 @@
 *Why Key Derivation Functions are not safe when using hardcoded values*
 
-Key Derivation Functions (KDFs) are deterministic in nature. This means that for a given input, they will always give back the same output. So, if the parameters are hardcoded in code, anyone with access to the code can run the KDF with the coded parameters and get the actual key.
+Key Derivation Functions (KDFs) are deterministic. This means that they will always give back the same output for a given input. So, if the parameters are hardcoded, anyone with access to the code can run the KDF with the specified parameters and get the key.
 
-KDFs should be used to generate keys based on dynamic input, such as human supplied passwords for instance. KDFs might be used in situations where secure random sources generate certain output which can be used to generate keys. Again, in both cases: the KDF its input is not hardcoded/deterministic.
+KDFs should be used to generate keys based on dynamic input, such as human-supplied passwords. KDFs might be used when secure random sources can be used to generate keys. Again, the KDF's input is not hardcoded/deterministic in both cases.

--- a/src/main/resources/explanations/challenge34_reason.adoc
+++ b/src/main/resources/explanations/challenge34_reason.adoc
@@ -1,0 +1,3 @@
+*Why Key Derivation Functions are not safe when using hardcoded values*
+
+TBD

--- a/src/main/resources/explanations/challenge34_reason.adoc
+++ b/src/main/resources/explanations/challenge34_reason.adoc
@@ -2,4 +2,4 @@
 
 Key Derivation Functions (KDFs) are deterministic in nature. This means that for a given input, they will always give back the same output. So, if the parameters are hardcoded in code, anyone with access to the code can run the KDF with the coded parameters and get the actual key.
 
-KDFs should be used to generate keys based on dynamic input, such as human supplied passwords for instance. KDFs might be used in situations where secure random sources generate certain output which can be used to generate keys. Again, in both cases: the KDF its input is not hardcoded/deterministic. 
+KDFs should be used to generate keys based on dynamic input, such as human supplied passwords for instance. KDFs might be used in situations where secure random sources generate certain output which can be used to generate keys. Again, in both cases: the KDF its input is not hardcoded/deterministic.

--- a/src/test/java/org/owasp/wrongsecrets/challenges/docker/Challenge34Test.java
+++ b/src/test/java/org/owasp/wrongsecrets/challenges/docker/Challenge34Test.java
@@ -1,0 +1,23 @@
+package org.owasp.wrongsecrets.challenges.docker;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.owasp.wrongsecrets.ScoreCard;
+
+public class Challenge34Test {
+  @Mock private ScoreCard scoreCard;
+
+  @Test
+  void spoilerShouldGiveAnswer() {
+    var challenge = new Challenge34(scoreCard);
+    Assertions.assertThat(challenge.spoiler().solution()).isNotEmpty();
+    Assertions.assertThat(challenge.answerCorrect(challenge.spoiler().solution())).isTrue();
+  }
+
+  @Test
+  void incorrectAnswerShouldNotSolveChallenge() {
+    var challenge = new Challenge34(scoreCard);
+    Assertions.assertThat(challenge.solved("wrong answer")).isFalse();
+  }
+}


### PR DESCRIPTION
 <!-- Thank you for submitting a pull request to the WrongSecrets app! See what makes a good PR at https://github.com/OWASP/wrongsecrets/blob/master/CONTRIBUTING.md-->

### What kind of changes does this PR include?

-   [ ] Fixes or refactors
-   [x] A new challenge: challenge on using KDFs on hardcoded keys
-   [ ] Additional documentation
-   [ ] Something else

#### Description

We now have seen various instances of people hardcoding keys, and using KDFs like PBKDF2 to "magically" generate safer not hardcoded keys, while using hardcoded values for teh function actually always generates the same (E.g. hardcoded) key.

### Relations

Closes #692 
### References

<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Checklist:

-   [x] All the contributions made are solely the work of me and my co-authors
-   [x] I tested the changes in this PR (if applicable)
-   [x] I added unit tests to ensure my change works (when change in Java or on front-end code)
-   [x] I added UI tests to ensure my UI changes work (when change in the overall UI, not needed if just adding a challenge)
-   [x] The PR passes pre-commit hooks and automated tests
