### PR TITLE
Replace Challenge32 with another prompting game (Gandalf)

### DIFF
--- a/src/main/java/org/owasp/wrongsecrets/challenges/docker/Challenge32.java
+++ b/src/main/java/org/owasp/wrongsecrets/challenges/docker/Challenge32.java
@@ -20,7 +20,7 @@ import org.springframework.stereotype.Component;
 
 /**
  * This is a challenge based on LLM where poeople need to extract the secret from
- * https://gpa.43z.one/
+ * https://https://gandalf.lakera.ai//
  */
 @Slf4j
 @Component
@@ -52,7 +52,7 @@ public class Challenge32 extends Challenge {
     return Difficulty.NORMAL;
   }
 
-  /** {@inheritDoc} This is a front-end / web type of challenge */
+  /** {@inheritDoc} This is an AI type of challenge */
   @Override
   public String getTech() {
     return ChallengeTechnology.Tech.AI.id;
@@ -72,7 +72,7 @@ public class Challenge32 extends Challenge {
     return decrypt(
         decrypt(
             decrypt(
-                "daBa42GnqZs8FtRZ4qmbURWt5+WUbibEE7hOoLV6J2d+zRth6GUzaQx+7N2KjofhoJmO4/io9jgcGdH8FKZrddnH8jWIMtd7hTXlnIST/CqcO5h5ir3HgLaQ863QRr3LGycvcaBU99vZB+ofm48JQa4F8DFSfrf0RIjwcQ==")));
+                    "BE8VK4p3wD7Rba3rA5bduOYG99yMhuyonyHC4JPm15VNHDU0ULORJB1oSBddWEWIA39oFP0osD+YVRX8zBZZeNdif9o1Prar3L1tbCc821PiOA6JOfZFOWscMTy0Plpo9jKsz8RBt4/Sp3xxJsjVaW+ZgBki+MeB7+rgUnK+elI5iu2E")));
   }
 
   private String decrypt(String cipherTextString) {

--- a/src/main/java/org/owasp/wrongsecrets/challenges/docker/Challenge32.java
+++ b/src/main/java/org/owasp/wrongsecrets/challenges/docker/Challenge32.java
@@ -72,7 +72,7 @@ public class Challenge32 extends Challenge {
     return decrypt(
         decrypt(
             decrypt(
-                    "BE8VK4p3wD7Rba3rA5bduOYG99yMhuyonyHC4JPm15VNHDU0ULORJB1oSBddWEWIA39oFP0osD+YVRX8zBZZeNdif9o1Prar3L1tbCc821PiOA6JOfZFOWscMTy0Plpo9jKsz8RBt4/Sp3xxJsjVaW+ZgBki+MeB7+rgUnK+elI5iu2E")));
+                "BE8VK4p3wD7Rba3rA5bduOYG99yMhuyonyHC4JPm15VNHDU0ULORJB1oSBddWEWIA39oFP0osD+YVRX8zBZZeNdif9o1Prar3L1tbCc821PiOA6JOfZFOWscMTy0Plpo9jKsz8RBt4/Sp3xxJsjVaW+ZgBki+MeB7+rgUnK+elI5iu2E")));
   }
 
   private String decrypt(String cipherTextString) {

--- a/src/main/resources/explanations/challenge32.adoc
+++ b/src/main/resources/explanations/challenge32.adoc
@@ -3,7 +3,9 @@
 AI is here to stay. AI can help with loads of things: complicated problem-solving, generating code, or giving advice on security.
 Imagine you've uploaded code to look for security issues. What if that included a password? Rules should limit the LLM model to prevent it from leaking the password. Can this secret be extracted nonetheless?
 
-Try to find it through https://gpa.43z.one/[this prompting game's] first exercise.
-(Built by https://twitter.com/h43z[h43z])
+Try to find it through https://gandalf.lakera.ai/[this prompting game's] first exercise.
 
-Please be aware that https://gpa.43z.one/[the prompting game] is completely free and open. this means that it might be offline and take a few minutes to run again after your first request. Please do not Fuzz or dynamic test the website (e.g., don't use ZAP or Burp). Make sure that others can play it as well!
+
+Please be aware that https://gandalf.lakera.ai/[the prompting game] is completely free and open. this means that it might be offline and take a few minutes to run again after your first request. Please do not Fuzz or dynamic test the website (e.g., don't use ZAP or Burp). Make sure that others can play it as well!
+
+Note, we used to use https://gpa.43z.one/[another prompting game] which was shutdown due to cost, so it might be that LLM/AI is not here to stay for everything ;-).

--- a/src/main/resources/explanations/challenge32_reason.adoc
+++ b/src/main/resources/explanations/challenge32_reason.adoc
@@ -1,6 +1,6 @@
 *Why you should be careful with AI (or ML) and secrets*
 
-Any AI/ML solution that relies on your input, might use that input for further improvement. This is sometimes referred to as "Reinforcement learning from human feedback". There are various applications in the world, such such as Co-Pilot, ChatGPT, and many others, which are based on this mechanism.
+Any AI/ML solution that relies on your input, might use that input for further improvement. This is sometimes referred to as "Reinforcement learning from human feedback". There are various applications in the world, such as Co-Pilot, ChatGPT, and many others, which are based on this mechanism.
 This means that when you use those and give them feedback or agree on sending them data to be more effective in helping you, then this data resides with them and might be queryable by others.
 
 Note that all user input is implicitly trusted. This means that if you overwhelm an LLM with loads of (repeated) text, you might be able to bypass some of its controls and tell it what to do.

--- a/src/test/java/org/owasp/wrongsecrets/challenges/docker/Challenge32Test.java
+++ b/src/test/java/org/owasp/wrongsecrets/challenges/docker/Challenge32Test.java
@@ -20,5 +20,4 @@ public class Challenge32Test {
     var challenge = new Challenge32(scoreCard);
     Assertions.assertThat(challenge.solved("wrong answer")).isFalse();
   }
-
 }

--- a/src/test/java/org/owasp/wrongsecrets/challenges/docker/Challenge32Test.java
+++ b/src/test/java/org/owasp/wrongsecrets/challenges/docker/Challenge32Test.java
@@ -20,4 +20,5 @@ public class Challenge32Test {
     var challenge = new Challenge32(scoreCard);
     Assertions.assertThat(challenge.solved("wrong answer")).isFalse();
   }
+
 }


### PR DESCRIPTION
 <!-- Thank you for submitting a pull request to the WrongSecrets app! See what makes a good PR at https://github.com/OWASP/wrongsecrets/blob/master/CONTRIBUTING.md-->

### What kind of changes does this PR include?

-   [x] Fixes or refactors: fix for https://github.com/OWASP/wrongsecrets/discussions/946
-   [ ] A new challenge
-   [ ] Additional documentation
-   [ ] Something else

#### Description

Fixes final part of https://github.com/OWASP/wrongsecrets/discussions/946 which replaces the prompting game with a new one that is still open.

### Relations

Closes #946

### References

<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Checklist:

-   [x] All the contributions made are solely the work of me and my co-authors
-   [x] I tested the changes in this PR (if applicable)
-   [x] I added unit tests to ensure my change works (when change in Java or on front-end code)
-   [x] I added UI tests to ensure my UI changes work (when change in the overall UI, not needed if just adding a challenge)
-   [x] The PR passes pre-commit hooks and automated tests
