### PR TITLE
feat: Challenge 39 based on filename as encryption key

### DIFF
--- a/src/main/java/org/owasp/wrongsecrets/challenges/docker/Challenge39.java
+++ b/src/main/java/org/owasp/wrongsecrets/challenges/docker/Challenge39.java
@@ -1,0 +1,100 @@
+package org.owasp.wrongsecrets.challenges.docker;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Objects;
+
+import org.owasp.wrongsecrets.RuntimeEnvironment;
+import org.owasp.wrongsecrets.ScoreCard;
+import org.owasp.wrongsecrets.challenges.Challenge;
+import org.owasp.wrongsecrets.challenges.ChallengeTechnology;
+import org.owasp.wrongsecrets.challenges.Difficulty;
+import org.owasp.wrongsecrets.challenges.Spoiler;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+/** This is a challenge based on leaking secrets with the misuse of Git notes */
+@Slf4j
+@Component
+@Order(39)
+public class Challenge39 extends Challenge {
+
+  private Resource resource;
+
+  public Challenge39(
+      ScoreCard scoreCard, @Value("classpath:executables/secrchallenge.md") Resource resource) {
+    super(scoreCard);
+    this.resource = resource;
+  }
+
+  @Override
+  public boolean canRunInCTFMode() {
+    return true;
+  }
+
+  @Override
+  public Spoiler spoiler() {
+    return new Spoiler(getSolution());
+  }
+
+  @Override
+  public boolean answerCorrect(String answer) {
+    return getSolution().equals(answer);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public int difficulty() {
+    return Difficulty.EASY;
+  }
+
+  /** {@inheritDoc} Cryptography based. */
+  @Override
+  public String getTech() {
+    return ChallengeTechnology.Tech.CRYPTOGRAPHY.id;
+  }
+
+  @Override
+  public boolean isLimitedWhenOnlineHosted() {
+    return false;
+  }
+
+  @Override
+  public List<RuntimeEnvironment.Environment> supportedRuntimeEnvironments() {
+    return List.of(RuntimeEnvironment.Environment.DOCKER);
+  }
+
+  private String getSolution() {
+    try {
+      String encryptedText = resource.getContentAsString(Charset.defaultCharset());
+      byte[] decodedEncryptedText = Base64.getDecoder().decode(encryptedText.trim());
+      byte[] decodedKey =
+          Objects.requireNonNull(resource.getFilename()).getBytes(StandardCharsets.UTF_8);
+
+      // Create a SecretKey from the plaintext key
+      SecretKey secretKey = new SecretKeySpec(decodedKey, "AES");
+
+      // Initialize the Cipher for decryption
+      Cipher cipher = Cipher.getInstance("AES");
+      cipher.init(Cipher.DECRYPT_MODE, secretKey);
+
+      // Decrypt the data
+      byte[] decryptedData = cipher.doFinal(decodedEncryptedText);
+
+      // Convert the decrypted bytes to a String
+      return new String(decryptedData, StandardCharsets.UTF_8);
+    } catch (Exception e) {
+      log.warn("there was an exception with decrypting content in challenge39", e);
+      return "error_decryption";
+    }
+  }
+}

--- a/src/main/java/org/owasp/wrongsecrets/challenges/docker/Challenge39.java
+++ b/src/main/java/org/owasp/wrongsecrets/challenges/docker/Challenge39.java
@@ -5,30 +5,28 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 import java.util.Objects;
-
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import lombok.extern.slf4j.Slf4j;
 import org.owasp.wrongsecrets.RuntimeEnvironment;
 import org.owasp.wrongsecrets.ScoreCard;
 import org.owasp.wrongsecrets.challenges.Challenge;
 import org.owasp.wrongsecrets.challenges.ChallengeTechnology;
 import org.owasp.wrongsecrets.challenges.Difficulty;
 import org.owasp.wrongsecrets.challenges.Spoiler;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 
-import javax.crypto.Cipher;
-import javax.crypto.SecretKey;
-import javax.crypto.spec.SecretKeySpec;
-
-/** This is a challenge based on leaking secrets with the misuse of Git notes */
+/** This is a challenge based on leaking secrets due to choice of filename as encryption key */
 @Slf4j
 @Component
 @Order(39)
 public class Challenge39 extends Challenge {
 
-  private Resource resource;
+  private final Resource resource;
 
   public Challenge39(
       ScoreCard scoreCard, @Value("classpath:executables/secrchallenge.md") Resource resource) {

--- a/src/main/resources/executables/secrchallenge.md
+++ b/src/main/resources/executables/secrchallenge.md
@@ -1,0 +1,1 @@
+LE82ckNsIxi35VIQewirz0WBnsOSqQL/sAW1XL4orHY=

--- a/src/main/resources/explanations/challenge39.adoc
+++ b/src/main/resources/explanations/challenge39.adoc
@@ -1,5 +1,5 @@
 === Insecure Encryption Key - Part 1
 
-A developer encrypted a secret using https://en.wikipedia.org/wiki/Advanced_Encryption_Standard[AES] and stored it's base64 encoded value in a file. The encryption key used was same as the name of the file containing the secret.
+A developer encrypted a secret using https://en.wikipedia.org/wiki/Advanced_Encryption_Standard[AES] and stored it's base64 encoded value in a file. But where to leave the key? What about just using the filename as the encryption key instead? That way, every secret can have its own key easily! Can you find the secret?
 
-The challenge file is called https://github.com/OWASP/wrongsecrets/tree/master/src/main/resources/executables/secrchallenge.md[secrchallenge.md] and can be found in the https://github.com/OWASP/wrongsecrets/tree/master/src/main/resources/executables[executables folder]. Can you get it?
+The challenge file is called https://github.com/OWASP/wrongsecrets/tree/master/src/main/resources/executables/secrchallenge.md[secrchallenge.md] and can be found in the https://github.com/OWASP/wrongsecrets/tree/master/src/main/resources/executables[executables folder].

--- a/src/main/resources/explanations/challenge39.adoc
+++ b/src/main/resources/explanations/challenge39.adoc
@@ -1,0 +1,5 @@
+=== Insecure Encryption Key - Part 1
+
+A developer encrypted a secret using https://en.wikipedia.org/wiki/Advanced_Encryption_Standard[AES] and stored it's base64 encoded value in a file. The encryption key used was same as the name of the file containing the secret.
+
+The challenge file is called https://github.com/OWASP/wrongsecrets/tree/master/src/main/resources/executables/secrchallenge.md[secrchallenge.md] and can be found in the https://github.com/OWASP/wrongsecrets/tree/master/src/main/resources/executables[executables folder]. Can you get it?

--- a/src/main/resources/explanations/challenge39.adoc
+++ b/src/main/resources/explanations/challenge39.adoc
@@ -1,5 +1,5 @@
 === Insecure Encryption Key - Part 1
 
-A developer encrypted a secret using https://en.wikipedia.org/wiki/Advanced_Encryption_Standard[AES] and stored it's base64 encoded value in a file. But where to leave the key? What about just using the filename as the encryption key instead? That way, every secret can have its own key easily! Can you find the secret?
+A developer encrypted a secret using https://en.wikipedia.org/wiki/Advanced_Encryption_Standard[AES] and stored its base64 encoded value in a file. But where to leave the key? What about just using the filename as the encryption key instead? That way, every secret can have its own key easily! Can you find the secret?
 
 The challenge file is called https://github.com/OWASP/wrongsecrets/tree/master/src/main/resources/executables/secrchallenge.md[secrchallenge.md] and can be found in the https://github.com/OWASP/wrongsecrets/tree/master/src/main/resources/executables[executables folder].

--- a/src/main/resources/explanations/challenge39_hint.adoc
+++ b/src/main/resources/explanations/challenge39_hint.adoc
@@ -1,6 +1,12 @@
-This challenge can be solved by decrypting the base64 encoded secret in `secrchallenge.md`.
+This challenge can be solved by decrypting the base64 encoded secret in `secrchallenge.md`. You can do this either by
 
-1. Copy the contents of the `secrchallenge.md` file.
-2. Decode the copied string from base64 to UTF-8.
-3. Decrypt it using any AES decryption tool with `secrchallenge.md` as decryption key.
-4. Paste the secret into the box.
+1. Using an online aes decryption tool like https://www.devglan.com/online-tools/aes-encryption-decryption[https://www.devglan.com/online-tools/aes-encryption-decryption]
+- Copy the contents of the `secrchallenge.md` file and paste it in the textbox of the decryptor.
+- Make sure that the input format is `Base64` and cipher mode is `ECB`.
+- Use `secrchallenge.md` as decryption key and click on `Decrypt` to get the secret.
+
+2. Using the terminal
+- Launch the terminal while you are in the `executables` directory.
+- Type in `echo -n "secrchallenge.md" | xxd -p` to convert the plaintext key to hexadecimal key.
+- Then use the obtained decryption key to decrypt the file by typing `openssl enc -a -d -aes-128-ecb -in secrchallenge.md -K 736563726368616c6c656e67652e6d64 -out decrypted.md`
+- Copy the secret from the `decrypted.md` file in the `executables` folder.

--- a/src/main/resources/explanations/challenge39_hint.adoc
+++ b/src/main/resources/explanations/challenge39_hint.adoc
@@ -1,0 +1,6 @@
+This challenge can be solved by decrypting the base64 encoded secret in `secrchallenge.md`.
+
+1. Copy the contents of the `secrchallenge.md` file.
+2. Decode the copied string from base64 to UTF-8.
+3. Decrypt it using any AES decryption tool with `secrchallenge.md` as decryption key.
+4. Paste the secret into the box.

--- a/src/main/resources/explanations/challenge39_hint.adoc
+++ b/src/main/resources/explanations/challenge39_hint.adoc
@@ -1,12 +1,12 @@
-This challenge can be solved by decrypting the base64 encoded secret in `secrchallenge.md`. You can do this either by
+This challenge can be solved by decrypting the base64 encoded secret in `secrchallenge.md`. You can do this either by:
 
 1. Using an online aes decryption tool like https://www.devglan.com/online-tools/aes-encryption-decryption[https://www.devglan.com/online-tools/aes-encryption-decryption]
-- Copy the contents of the `secrchallenge.md` file and paste it in the textbox of the decryptor.
-- Make sure that the input format is `Base64` and cipher mode is `ECB`.
+- Copy the contents of the `secrchallenge.md` file and paste it into the textbox of the decryptor.
+- Ensure the input format is `Base64` and the cipher mode is `ECB`.
 - Use `secrchallenge.md` as decryption key and click on `Decrypt` to get the secret.
 
 2. Using the terminal
 - Launch the terminal while you are in the `executables` directory.
-- Type in `echo -n "secrchallenge.md" | xxd -p` to convert the plaintext key to hexadecimal key.
-- Then use the obtained decryption key to decrypt the file by typing `openssl enc -a -d -aes-128-ecb -in secrchallenge.md -K 736563726368616c6c656e67652e6d64 -out decrypted.md`
+- Type in `echo -n "secrchallenge.md" | xxd -p` to convert the plaintext key to a hexadecimal key.
+- Then, use the obtained decryption key to decrypt the file by typing `openssl enc -a -d -aes-128-ecb -in secrchallenge.md -K 736563726368616c6c656e67652e6d64 -out decrypted.md`
 - Copy the secret from the `decrypted.md` file in the `executables` folder.

--- a/src/main/resources/explanations/challenge39_reason.adoc
+++ b/src/main/resources/explanations/challenge39_reason.adoc
@@ -1,5 +1,5 @@
-*Why we should not use filename as encryption key?*
+*Why should we not use the filename as the encryption key?*
 
-There have been multiple scenarios where the contents of files were encrypted using the filename itself, which allows attackers to easily decrypt its contents. It is often perceived as an easy way to keep the key close to the content, without reusing the same encryption key everywhere.
+There have been multiple scenarios where the contents of files were encrypted using the filename itself, which allows attackers to easily decrypt its contents easily. It is often perceived as an easy way to keep the key close to the content, without reusing the same encryption key everywhere.
 
-But as you can tell by now: this is not a good idea. An attacker has the key the moment the file is in his possession.
+But as you can tell by now, this is not a good idea. An attacker has the key the moment the file is in his possession.

--- a/src/main/resources/explanations/challenge39_reason.adoc
+++ b/src/main/resources/explanations/challenge39_reason.adoc
@@ -1,0 +1,3 @@
+*Why we should not use filename as encryption key?*
+
+There have been multiple scenarios where the contents of files were encrypted using the filename itself, which allows attackers to easily decrypt its contents.

--- a/src/main/resources/explanations/challenge39_reason.adoc
+++ b/src/main/resources/explanations/challenge39_reason.adoc
@@ -1,3 +1,5 @@
 *Why we should not use filename as encryption key?*
 
-There have been multiple scenarios where the contents of files were encrypted using the filename itself, which allows attackers to easily decrypt its contents.
+There have been multiple scenarios where the contents of files were encrypted using the filename itself, which allows attackers to easily decrypt its contents. It is often perceived as an easy way to keep the key close to the content, without reusing the same encryption key everywhere.
+
+But as you can tell by now: this is not a good idea. An attacker has the key the moment the file is in his possession.

--- a/src/test/java/org/owasp/wrongsecrets/challenges/docker/Challenge39Test.java
+++ b/src/test/java/org/owasp/wrongsecrets/challenges/docker/Challenge39Test.java
@@ -1,0 +1,41 @@
+package org.owasp.wrongsecrets.challenges.docker;
+
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.owasp.wrongsecrets.ScoreCard;
+import org.springframework.core.io.Resource;
+
+@ExtendWith(MockitoExtension.class)
+class Challenge39Test {
+  @Mock private ScoreCard scoreCard;
+
+  @Mock private Resource resource;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    when(resource.getContentAsString(Charset.defaultCharset()))
+        .thenReturn("YHh0aLDtW6WjFwlOgDrcRELRBIaAW9IUqR6sPy8NyYQ=");
+    when(resource.getFilename()).thenReturn("secrchallenge.md");
+  }
+
+  @Test
+  void spoilerShouldGiveAnswer() {
+    var challenge = new Challenge39(scoreCard, resource);
+    Assertions.assertThat(challenge.spoiler().solution()).isNotEmpty();
+    Assertions.assertThat(challenge.answerCorrect(challenge.spoiler().solution())).isTrue();
+  }
+
+  @Test
+  void incorrectAnswerShouldNotSolveChallenge() {
+    var challenge = new Challenge39(scoreCard, resource);
+    Assertions.assertThat(challenge.answerCorrect("wrong answer")).isFalse();
+  }
+}

--- a/src/test/java/org/owasp/wrongsecrets/challenges/docker/Challenge39Test.java
+++ b/src/test/java/org/owasp/wrongsecrets/challenges/docker/Challenge39Test.java
@@ -31,6 +31,7 @@ class Challenge39Test {
     var challenge = new Challenge39(scoreCard, resource);
     Assertions.assertThat(challenge.spoiler().solution()).isNotEmpty();
     Assertions.assertThat(challenge.answerCorrect(challenge.spoiler().solution())).isTrue();
+    Assertions.assertThat(challenge.answerCorrect("error_decryption")).isFalse();
   }
 
   @Test


### PR DESCRIPTION
### What kind of changes does this PR include?

-   [ ] Fixes or refactors
-   [x] A new challenge
-   [ ] Additional documentation
-   [ ] Something else

#### Description

Adds challenge 39, which is based on weak encryption due to the choice of filename as encryption key.

### Relations

Relates #975 

### Checklist:

-   [x] All the contributions made are solely the work of me and my co-authors
-   [x] I tested the changes in this PR (if applicable)
-   [x] I added unit tests to ensure my change works (when change in Java or on front-end code)
-   [x] The PR passes pre-commit hooks and automated tests
