### PR TITLE
feat: Challenge 40 based on storing encryption key and secret in the same file

### DIFF
--- a/src/main/java/org/owasp/wrongsecrets/challenges/docker/Challenge40.java
+++ b/src/main/java/org/owasp/wrongsecrets/challenges/docker/Challenge40.java
@@ -1,0 +1,108 @@
+package org.owasp.wrongsecrets.challenges.docker;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import lombok.extern.slf4j.Slf4j;
+import org.owasp.wrongsecrets.RuntimeEnvironment;
+import org.owasp.wrongsecrets.ScoreCard;
+import org.owasp.wrongsecrets.challenges.Challenge;
+import org.owasp.wrongsecrets.challenges.ChallengeTechnology;
+import org.owasp.wrongsecrets.challenges.Difficulty;
+import org.owasp.wrongsecrets.challenges.Spoiler;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Component;
+
+/**
+ * This is a challenge based on leaking secrets due to keeping the encryption key and secret
+ * together
+ */
+@Slf4j
+@Component
+@Order(40)
+public class Challenge40 extends Challenge {
+
+  private final Resource resource;
+
+  public Challenge40(
+      ScoreCard scoreCard, @Value("classpath:executables/secrchallenge.json") Resource resource) {
+    super(scoreCard);
+    this.resource = resource;
+  }
+
+  @Override
+  public boolean canRunInCTFMode() {
+    return true;
+  }
+
+  @Override
+  public Spoiler spoiler() {
+    return new Spoiler(getSolution());
+  }
+
+  @Override
+  public boolean answerCorrect(String answer) {
+    return getSolution().equals(answer);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public int difficulty() {
+    return Difficulty.EASY;
+  }
+
+  /** {@inheritDoc} Cryptography based. */
+  @Override
+  public String getTech() {
+    return ChallengeTechnology.Tech.CRYPTOGRAPHY.id;
+  }
+
+  @Override
+  public boolean isLimitedWhenOnlineHosted() {
+    return false;
+  }
+
+  @Override
+  public List<RuntimeEnvironment.Environment> supportedRuntimeEnvironments() {
+    return List.of(RuntimeEnvironment.Environment.DOCKER);
+  }
+
+  @SuppressFBWarnings(
+      value = {"CIPHER_INTEGRITY", "ECB_MODE"},
+      justification = "This is to allow for easy ECB online decryptors")
+  private String getSolution() {
+    try {
+      String jsonContent = resource.getContentAsString(Charset.defaultCharset());
+      ObjectMapper objectMapper = new ObjectMapper();
+      JsonNode jsonNode = objectMapper.readTree(jsonContent);
+      String encryptedText = jsonNode.get("secret").asText();
+      byte[] decodedEncryptedText = Base64.getDecoder().decode(encryptedText.trim());
+      byte[] plainDecryptionKey = jsonNode.get("key").asText().getBytes(StandardCharsets.UTF_8);
+
+      // Create a SecretKey from the plaintext key
+      SecretKey secretKey = new SecretKeySpec(plainDecryptionKey, "AES");
+
+      // Initialize the Cipher for decryption
+      Cipher cipher = Cipher.getInstance("AES");
+      cipher.init(Cipher.DECRYPT_MODE, secretKey);
+
+      // Decrypt the data
+      byte[] decryptedData = cipher.doFinal(decodedEncryptedText);
+
+      // Convert the decrypted bytes to a String
+      return new String(decryptedData, StandardCharsets.UTF_8);
+    } catch (Exception e) {
+      log.warn("there was an exception with decrypting content in challenge40", e);
+      return "error_decryption";
+    }
+  }
+}

--- a/src/main/resources/executables/secrchallenge.json
+++ b/src/main/resources/executables/secrchallenge.json
@@ -1,0 +1,4 @@
+{
+    "key":"3Ulyfmfgro6uh1cN",
+    "secret":"7RwunHeLkY7c0TCTLRMOGCIeX0jWiYibAexA0unYGDI="
+}

--- a/src/main/resources/explanations/challenge40.adoc
+++ b/src/main/resources/explanations/challenge40.adoc
@@ -1,0 +1,5 @@
+=== Insecure Encryption Key - Part 2
+
+A developer encrypted a secret using https://en.wikipedia.org/wiki/Advanced_Encryption_Standard[AES] and stored its base64 encoded value in a json file. But where to leave the key? What about just leaving the key inside the file with the secret? That way, every secret can have its own key easily! Can you find the secret?
+
+The challenge file is called https://github.com/OWASP/wrongsecrets/tree/master/src/main/resources/executables/secrchallenge.json[secrchallenge.json] and can be found in the https://github.com/OWASP/wrongsecrets/tree/master/src/main/resources/executables[executables folder].

--- a/src/main/resources/explanations/challenge40_hint.adoc
+++ b/src/main/resources/explanations/challenge40_hint.adoc
@@ -1,0 +1,13 @@
+This challenge can be solved by decrypting the base64 encoded secret in `secrchallenge.json`. You can do this either by:
+
+1. Using an online aes decryption tool like https://www.devglan.com/online-tools/aes-encryption-decryption[https://www.devglan.com/online-tools/aes-encryption-decryption]
+- Copy the value of `secret` from `secrchallenge.json` and paste it into the textbox of the decryptor.
+- Ensure the input format is `Base64` and the cipher mode is `ECB`.
+- Use the value of `key` from `secrchallenge.json` as decryption key and click on `Decrypt` to get the secret.
+
+2. Using the terminal
+- Launch the terminal while you are in the `executables` directory.
+- Copy the value of `key` from `secrchallenge.json` and type in `echo -n "3Ulyfmfgro6uh1cN" | xxd -p`. This gives you the decryption key in hexadecimal format.
+- Copy the value of `secret` from `secrchallenge.json`.
+- Then, use the obtained decryption key to decrypt the by typing `echo "7RwunHeLkY7c0TCTLRMOGCIeX0jWiYibAexA0unYGDI=" | openssl enc -a -d -aes-128-ecb -K 33556c79666d6667726f36756831634e -out decrypted.md`
+- Copy the secret from the `decrypted.md` file in the `executables` folder.

--- a/src/main/resources/explanations/challenge40_reason.adoc
+++ b/src/main/resources/explanations/challenge40_reason.adoc
@@ -1,0 +1,7 @@
+*Why should we not store the encryption key and the secret together?*
+
+Storing an encryption key and the data it encrypts together is generally considered a bad practice because it undermines the security provided by encryption.
+
+In such scenarios, an attacker has the key the moment the file is in his possession.
+
+It is always recommended to store your encryption keys securely.

--- a/src/test/java/org/owasp/wrongsecrets/challenges/docker/Challenge40Test.java
+++ b/src/test/java/org/owasp/wrongsecrets/challenges/docker/Challenge40Test.java
@@ -1,0 +1,41 @@
+package org.owasp.wrongsecrets.challenges.docker;
+
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.owasp.wrongsecrets.ScoreCard;
+import org.springframework.core.io.Resource;
+
+@ExtendWith(MockitoExtension.class)
+class Challenge40Test {
+  @Mock private ScoreCard scoreCard;
+
+  @Mock private Resource resource;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    when(resource.getContentAsString(Charset.defaultCharset()))
+        .thenReturn("{ \"key\": \"sample_key123456\", \"secret\": \"8uVivR1M4yra5714Z58MKQ==\"}");
+  }
+
+  @Test
+  void spoilerShouldGiveAnswer() {
+    var challenge = new Challenge40(scoreCard, resource);
+    Assertions.assertThat(challenge.spoiler().solution()).isNotEmpty();
+    Assertions.assertThat(challenge.answerCorrect(challenge.spoiler().solution())).isTrue();
+    Assertions.assertThat(challenge.answerCorrect("error_decryption")).isFalse();
+  }
+
+  @Test
+  void incorrectAnswerShouldNotSolveChallenge() {
+    var challenge = new Challenge40(scoreCard, resource);
+    Assertions.assertThat(challenge.answerCorrect("wrong answer")).isFalse();
+  }
+}


### PR DESCRIPTION
### What kind of changes does this PR include?

-   [ ] Fixes or refactors
-   [x] A new challenge
-   [ ] Additional documentation
-   [ ] Something else

#### Description

Adds challenge 40, which is based on insecure encryption due to storing the encryption key and secret in the same file.

### Relations

Closes #975 


### Checklist:

-   [x] All the contributions made are solely the work of me and my co-authors
-   [x] I tested the changes in this PR (if applicable)
-   [x] I added unit tests to ensure my change works (when change in Java or on front-end code)
-   [ ] I added UI tests to ensure my UI changes work (when change in the overall UI, not needed if just adding a challenge)
-   [x] The PR passes pre-commit hooks and automated tests
