### PR TITLE
Added github actions to un-assigned issues after 90 days of inactivity

### DIFF
--- a/.github/workflows/project-management.yml
+++ b/.github/workflows/project-management.yml
@@ -15,6 +15,6 @@ jobs:
         with:
           last-activity: 90 # After how many days the issue should get unassigned
           labels: 'stale,help wanted' # Only search for issues containing this labels (comma-separated)
-          exempt-assignees: 'Octo,Cat' # Exempt some assignees from being unassigned
+          exempt-assignees: 'Octo,Cat,bendehaan,commjoen' # Exempt some assignees from being unassigned
           # labels-to-remove: 'Stale' # Labels to remove after unassigning an issue
           message: 'Automatically unassigned after 90 days of inactivity.'

--- a/.github/workflows/project-management.yml
+++ b/.github/workflows/project-management.yml
@@ -1,0 +1,20 @@
+name: Project Management
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+
+jobs:
+  # Best used in combination with actions/stale to assign a Stale label
+  unassign-issues-labeled-waiting-for-contributor-after-90-days-of-inactivity:
+    name: Unassign issues labeled "Stale" after 90 days of inactivity.
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: boundfoxstudios/action-unassign-contributor-after-days-of-inactivity@main
+        with:
+          last-activity: 90 # After how many days the issue should get unassigned
+          labels: 'stale,help wanted' # Only search for issues containing this labels (comma-separated)
+          exempt-assignees: 'Octo,Cat' # Exempt some assignees from being unassigned
+          # labels-to-remove: 'Stale' # Labels to remove after unassigning an issue
+          message: 'Automatically unassigned after 90 days of inactivity.'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,8 @@ The minimum requirements for code contributions are:
 3. New and changed lessons _must_ have a corresponding integration test.
 4. [Status checks](https://docs.github.com/en/github/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks) should pass for your last commit.
 
+And please note that this project has *three months* implementation windows. So once you've been assigned to a task/issue, try to make your PR accepted within this period.
+
 Additionally, the following guidelines can help:
 
 ### Keep your pull requests limited to a single issue


### PR DESCRIPTION
Issue https://github.com/OWASP/wrongsecrets/issues/1016

 <!-- Thank you for submitting a pull request to the WrongSecrets app! See what makes a good PR at https://github.com/OWASP/wrongsecrets/blob/master/CONTRIBUTING.md-->

### What kind of changes does this PR include?

-   [ ] Fixes or refactors
-   [ ] A new challenge
-   [ ] Additional documentation
-   [x] Something else

#### Description

<!---
Please provide a helpful summary of what change this pull request will introduce.
--->

### Relations

<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
Closes #0000
--->

### References

<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Checklist:

-   [ ] All the contributions made are solely the work of me and my co-authors
-   [ ] I tested the changes in this PR (if applicable)
-   [ ] I added unit tests to ensure my change works (when change in Java or on front-end code)
-   [ ] I added UI tests to ensure my UI changes work (when change in the overall UI, not needed if just adding a challenge)
-   [x] The PR passes pre-commit hooks and automated tests
