### PR TITLE
Hotfixes k8s defs, terratest and initial testing on okteto ctf

### DIFF
--- a/aws/wrongsecrets_aws_test.go
+++ b/aws/wrongsecrets_aws_test.go
@@ -1,98 +1,98 @@
 package test
 
 import (
-	"fmt"
-	"log"
-	"os"
-	"os/exec"
-	"strings"
-	"testing"
-	"time"
+    "fmt"
+    "log"
+    "os"
+    "os/exec"
+    "strings"
+    "testing"
+    "time"
 
-	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
+    http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
 
-	"github.com/gruntwork-io/terratest/modules/terraform"
+    "github.com/gruntwork-io/terratest/modules/terraform"
 )
 
 var START_SCRIPT = "./k8s-vault-aws-start.sh"
 var LB_SCRIPT = "./k8s-aws-alb-script.sh"
 
 func TestTerraformWrongSecretsAWS(t *testing.T) {
-	t.Parallel()
+    t.Parallel()
 
-	// Construct the terraform options with default retryable errors to handle the most common
-	// retryable errors in terraform testing.
-	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-		// The path to where our Terraform code is located
-		TerraformDir: "../aws",
-		Vars: map[string]interface{}{
-			"region": "eu-west-1",
-			"tags": map[string]string{
-				"Environment": "test",
-				"Application": "wrongsecrets",
-				"CreatedBy":   "Terratest",
-			},
-		},
-	})
+    // Construct the terraform options with default retryable errors to handle the most common
+    // retryable errors in terraform testing.
+    terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+        // The path to where our Terraform code is located
+        TerraformDir: "../aws",
+        Vars: map[string]interface{}{
+            "region": "eu-west-1",
+            "tags": map[string]string{
+                "Environment": "test",
+                "Application": "wrongsecrets",
+                "CreatedBy":   "Terratest",
+            },
+        },
+    })
 
-	// At the end of the test, run `terraform destroy` to clean up any resources that were created.
-	// Also run the cleanup script to remove the ALB resources
-	defer terraform.Destroy(t, terraformOptions)
-	cleanupCommand := []string{LB_SCRIPT}
-	defer execute(LB_SCRIPT, cleanupCommand)
+    // At the end of the test, run `terraform destroy` to clean up any resources that were created.
+    // Also run the cleanup script to remove the ALB resources
+    defer terraform.Destroy(t, terraformOptions)
+    cleanupCommand := []string{LB_SCRIPT}
+    defer execute(LB_SCRIPT, cleanupCommand)
 
-	// Run `terraform init` and `terraform apply`. Fail the test if there are any errors.
-	terraform.InitAndApply(t, terraformOptions)
+    // Run `terraform init` and `terraform apply`. Fail the test if there are any errors.
+    terraform.InitAndApply(t, terraformOptions)
 
-	// Run `terraform output` to get the endpoint of the cluster
-	// wrongsecretsClusterEndpoint := terraform.Output(t, terraformOptions, "cluster_endpoint")
+    // Run `terraform output` to get the endpoint of the cluster
+    // wrongsecretsClusterEndpoint := terraform.Output(t, terraformOptions, "cluster_endpoint")
 
-	command := []string{START_SCRIPT}
-	execute(START_SCRIPT, command)
+    command := []string{START_SCRIPT}
+    execute(START_SCRIPT, command)
 
-	// Make an HTTP request to the instance and make sure we get back a 200 OK with the body "Hello, World!"
-	challenge9 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil-9")
-	challenge10 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil-10")
-	challenge11 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil-11")
+    // Make an HTTP request to the instance and make sure we get back a 200 OK with the body "Hello, World!"
+    challenge9 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-9")
+    challenge10 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-10")
+    challenge11 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-11")
 
-	// Make an HTTP request to the instance and make sure we get back a 200 OK and don't see expected string. Retries for a while.
-	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge9, nil, 30, 5*time.Second, validateResponse)
-	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge10, nil, 30, 5*time.Second, validateResponse)
-	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge11, nil, 30, 5*time.Second, validateResponse)
+    // Make an HTTP request to the instance and make sure we get back a 200 OK and don't see expected string. Retries for a while.
+    http_helper.HttpGetWithRetryWithCustomValidation(t, challenge9, nil, 30, 5*time.Second, validateResponse)
+    http_helper.HttpGetWithRetryWithCustomValidation(t, challenge10, nil, 30, 5*time.Second, validateResponse)
+    http_helper.HttpGetWithRetryWithCustomValidation(t, challenge11, nil, 30, 5*time.Second, validateResponse)
 }
 
 func validateResponse(statusCode int, body string) bool {
-	// body should not contain if_you_see_this_please_use_AWS_Setup
-	if strings.Contains(body, "if_you_see_this_please_use_AWS_Setup") {
-		log.Printf("Found if_you_see_this_please_use_AWS_Setup in response body")
-		return false
-	}
-	// body should not contain please_use_supported_cloud_env
-	if strings.Contains(body, "please_use_supported_cloud_env") {
-		log.Printf("Found please_use_supported_cloud_env in response body")
-		return false
-	}
-	return statusCode == 200
+    // body should not contain if_you_see_this_please_use_AWS_Setup
+    if strings.Contains(body, "if_you_see_this_please_use_AWS_Setup") {
+        log.Printf("Found if_you_see_this_please_use_AWS_Setup in response body")
+        return false
+    }
+    // body should not contain please_use_supported_cloud_env
+    if strings.Contains(body, "please_use_supported_cloud_env") {
+        log.Printf("Found please_use_supported_cloud_env in response body")
+        return false
+    }
+    return statusCode == 200
 }
 
 func execute(script string, command []string) (bool, error) {
 
-	cmd := &exec.Cmd{
-		Path:   script,
-		Args:   command,
-		Stdout: os.Stdout,
-		Stderr: os.Stderr,
-	}
+    cmd := &exec.Cmd{
+        Path:   script,
+        Args:   command,
+        Stdout: os.Stdout,
+        Stderr: os.Stderr,
+    }
 
-	err := cmd.Start()
-	if err != nil {
-		return false, err
-	}
+    err := cmd.Start()
+    if err != nil {
+        return false, err
+    }
 
-	err = cmd.Wait()
-	if err != nil {
-		return false, err
-	}
+    err = cmd.Wait()
+    if err != nil {
+        return false, err
+    }
 
-	return true, nil
+    return true, nil
 }

--- a/azure/wrongsecrets_azure_test.go
+++ b/azure/wrongsecrets_azure_test.go
@@ -1,91 +1,91 @@
 package test
 
 import (
-	"fmt"
-	"log"
-	"os"
-	"os/exec"
-	"strings"
-	"testing"
-	"time"
+    "fmt"
+    "log"
+    "os"
+    "os/exec"
+    "strings"
+    "testing"
+    "time"
 
-	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
+    http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
 
-	"github.com/gruntwork-io/terratest/modules/terraform"
+    "github.com/gruntwork-io/terratest/modules/terraform"
 )
 
 var START_SCRIPT = "./k8s-vault-azure-start.sh"
 
 func TestTerraformWrongSecretsAzure(t *testing.T) {
-	t.Parallel()
+    t.Parallel()
 
-	// Construct the terraform options with default retryable errors to handle the most common
-	// retryable errors in terraform testing.
-	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-		// The path to where our Terraform code is located
-		TerraformDir: "../azure",
-		Vars: map[string]interface{}{
-			"region": "East US",
-		},
-	})
+    // Construct the terraform options with default retryable errors to handle the most common
+    // retryable errors in terraform testing.
+    terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+        // The path to where our Terraform code is located
+        TerraformDir: "../azure",
+        Vars: map[string]interface{}{
+            "region": "East US",
+        },
+    })
 
-	// At the end of the test, run `terraform destroy` to clean up any resources that were created.
-	defer terraform.Destroy(t, terraformOptions)
+    // At the end of the test, run `terraform destroy` to clean up any resources that were created.
+    defer terraform.Destroy(t, terraformOptions)
 
-	// Run `terraform init` and `terraform apply`. Fail the test if there are any errors.
-	terraform.InitAndApply(t, terraformOptions)
+    // Run `terraform init` and `terraform apply`. Fail the test if there are any errors.
+    terraform.InitAndApply(t, terraformOptions)
 
-	// Run `terraform output` to get the endpoint of the cluster
-	// wrongsecretsClusterEndpoint := terraform.Output(t, terraformOptions, "cluster_endpoint")
+    // Run `terraform output` to get the endpoint of the cluster
+    // wrongsecretsClusterEndpoint := terraform.Output(t, terraformOptions, "cluster_endpoint")
 
-	command := []string{
-		START_SCRIPT,
-	}
-	execute(START_SCRIPT, command)
+    command := []string{
+        START_SCRIPT,
+    }
+    execute(START_SCRIPT, command)
 
-	// Make an HTTP request to the instance and make sure we get back a 200 OK with the body "Hello, World!"
-	challenge9 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil-9")
-	challenge10 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil-10")
-	challenge11 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil-11")
+    // Make an HTTP request to the instance and make sure we get back a 200 OK with the body "Hello, World!"
+    challenge9 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-9")
+    challenge10 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-10")
+    challenge11 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-11")
 
-	// Make an HTTP request to the instance and make sure we get back a 200 OK and don't see expected string. Retries for a while.
-	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge9, nil, 30, 5*time.Second, validateResponse)
-	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge10, nil, 30, 5*time.Second, validateResponse)
-	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge11, nil, 30, 5*time.Second, validateResponse)
+    // Make an HTTP request to the instance and make sure we get back a 200 OK and don't see expected string. Retries for a while.
+    http_helper.HttpGetWithRetryWithCustomValidation(t, challenge9, nil, 30, 5*time.Second, validateResponse)
+    http_helper.HttpGetWithRetryWithCustomValidation(t, challenge10, nil, 30, 5*time.Second, validateResponse)
+    http_helper.HttpGetWithRetryWithCustomValidation(t, challenge11, nil, 30, 5*time.Second, validateResponse)
 }
 
 func validateResponse(statusCode int, body string) bool {
-	// body should not contain if_you_see_this_please_use_AWS_Setup
-	if strings.Contains(body, "if_you_see_this_please_use_AWS_Setup") {
-		log.Printf("Found if_you_see_this_please_use_AWS_Setup in response body")
-		return false
-	}
-	// body should not contain please_use_supported_cloud_env
-	if strings.Contains(body, "please_use_supported_cloud_env") {
-		log.Printf("Found please_use_supported_cloud_env in response body")
-		return false
-	}
-	return statusCode == 200
+    // body should not contain if_you_see_this_please_use_AWS_Setup
+    if strings.Contains(body, "if_you_see_this_please_use_AWS_Setup") {
+        log.Printf("Found if_you_see_this_please_use_AWS_Setup in response body")
+        return false
+    }
+    // body should not contain please_use_supported_cloud_env
+    if strings.Contains(body, "please_use_supported_cloud_env") {
+        log.Printf("Found please_use_supported_cloud_env in response body")
+        return false
+    }
+    return statusCode == 200
 }
 
 func execute(script string, command []string) (bool, error) {
 
-	cmd := &exec.Cmd{
-		Path:   script,
-		Args:   command,
-		Stdout: os.Stdout,
-		Stderr: os.Stderr,
-	}
+    cmd := &exec.Cmd{
+        Path:   script,
+        Args:   command,
+        Stdout: os.Stdout,
+        Stderr: os.Stderr,
+    }
 
-	err := cmd.Start()
-	if err != nil {
-		return false, err
-	}
+    err := cmd.Start()
+    if err != nil {
+        return false, err
+    }
 
-	err = cmd.Wait()
-	if err != nil {
-		return false, err
-	}
+    err = cmd.Wait()
+    if err != nil {
+        return false, err
+    }
 
-	return true, nil
+    return true, nil
 }

--- a/gcp/wrongsecrets_gcp_test.go
+++ b/gcp/wrongsecrets_gcp_test.go
@@ -1,92 +1,92 @@
 package test
 
 import (
-	"fmt"
-	"log"
-	"os"
-	"os/exec"
-	"strings"
-	"testing"
-	"time"
+    "fmt"
+    "log"
+    "os"
+    "os/exec"
+    "strings"
+    "testing"
+    "time"
 
-	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
+    http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
 
-	"github.com/gruntwork-io/terratest/modules/terraform"
+    "github.com/gruntwork-io/terratest/modules/terraform"
 )
 
 var START_SCRIPT = "./k8s-vault-gcp-start.sh"
 
 func TestTerraformWrongSecretsGCP(t *testing.T) {
-	t.Parallel()
+    t.Parallel()
 
-	// Construct the terraform options with default retryable errors to handle the most common
-	// retryable errors in terraform testing.
-	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-		// The path to where our Terraform code is located
-		TerraformDir: "../gcp",
-		Vars: map[string]interface{}{
-			"region":     "europe-west4",
-			"project_id": "owasp-wrongsecrets",
-		},
-	})
+    // Construct the terraform options with default retryable errors to handle the most common
+    // retryable errors in terraform testing.
+    terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+        // The path to where our Terraform code is located
+        TerraformDir: "../gcp",
+        Vars: map[string]interface{}{
+            "region":     "europe-west4",
+            "project_id": "owasp-wrongsecrets",
+        },
+    })
 
-	// At the end of the test, run `terraform destroy` to clean up any resources that were created.
-	defer terraform.Destroy(t, terraformOptions)
+    // At the end of the test, run `terraform destroy` to clean up any resources that were created.
+    defer terraform.Destroy(t, terraformOptions)
 
-	// Run `terraform init` and `terraform apply`. Fail the test if there are any errors.
-	terraform.InitAndApply(t, terraformOptions)
+    // Run `terraform init` and `terraform apply`. Fail the test if there are any errors.
+    terraform.InitAndApply(t, terraformOptions)
 
-	// Run `terraform output` to get the endpoint of the cluster
-	// wrongsecretsClusterEndpoint := terraform.Output(t, terraformOptions, "cluster_endpoint")
+    // Run `terraform output` to get the endpoint of the cluster
+    // wrongsecretsClusterEndpoint := terraform.Output(t, terraformOptions, "cluster_endpoint")
 
-	command := []string{
-		START_SCRIPT,
-	}
-	execute(START_SCRIPT, command)
+    command := []string{
+        START_SCRIPT,
+    }
+    execute(START_SCRIPT, command)
 
-	// Make an HTTP request to the instance and make sure we get back a 200 OK with the body "Hello, World!"
-	challenge9 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil-9")
-	challenge10 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil-10")
-	challenge11 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil-11")
+    // Make an HTTP request to the instance and make sure we get back a 200 OK with the body "Hello, World!"
+    challenge9 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-9")
+    challenge10 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-10")
+    challenge11 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-11")
 
-	// Make an HTTP request to the instance and make sure we get back a 200 OK and don't see expected string. Retries for a while.
-	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge9, nil, 30, 5*time.Second, validateResponse)
-	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge10, nil, 30, 5*time.Second, validateResponse)
-	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge11, nil, 30, 5*time.Second, validateResponse)
+    // Make an HTTP request to the instance and make sure we get back a 200 OK and don't see expected string. Retries for a while.
+    http_helper.HttpGetWithRetryWithCustomValidation(t, challenge9, nil, 30, 5*time.Second, validateResponse)
+    http_helper.HttpGetWithRetryWithCustomValidation(t, challenge10, nil, 30, 5*time.Second, validateResponse)
+    http_helper.HttpGetWithRetryWithCustomValidation(t, challenge11, nil, 30, 5*time.Second, validateResponse)
 }
 
 func validateResponse(statusCode int, body string) bool {
-	// body should not contain if_you_see_this_please_use_AWS_Setup
-	if strings.Contains(body, "if_you_see_this_please_use_AWS_Setup") {
-		log.Printf("Found if_you_see_this_please_use_AWS_Setup in response body")
-		return false
-	}
-	// body should not contain please_use_supported_cloud_env
-	if strings.Contains(body, "please_use_supported_cloud_env") {
-		log.Printf("Found please_use_supported_cloud_env in response body")
-		return false
-	}
-	return statusCode == 200
+    // body should not contain if_you_see_this_please_use_AWS_Setup
+    if strings.Contains(body, "if_you_see_this_please_use_AWS_Setup") {
+        log.Printf("Found if_you_see_this_please_use_AWS_Setup in response body")
+        return false
+    }
+    // body should not contain please_use_supported_cloud_env
+    if strings.Contains(body, "please_use_supported_cloud_env") {
+        log.Printf("Found please_use_supported_cloud_env in response body")
+        return false
+    }
+    return statusCode == 200
 }
 
 func execute(script string, command []string) (bool, error) {
 
-	cmd := &exec.Cmd{
-		Path:   script,
-		Args:   command,
-		Stdout: os.Stdout,
-		Stderr: os.Stderr,
-	}
+    cmd := &exec.Cmd{
+        Path:   script,
+        Args:   command,
+        Stdout: os.Stdout,
+        Stderr: os.Stderr,
+    }
 
-	err := cmd.Start()
-	if err != nil {
-		return false, err
-	}
+    err := cmd.Start()
+    if err != nil {
+        return false, err
+    }
 
-	err = cmd.Wait()
-	if err != nil {
-		return false, err
-	}
+    err = cmd.Wait()
+    if err != nil {
+        return false, err
+    }
 
-	return true, nil
+    return true, nil
 }

--- a/k8s/secret-challenge-vault-deployment.yml
+++ b/k8s/secret-challenge-vault-deployment.yml
@@ -77,7 +77,7 @@ spec:
           terminationMessagePolicy: File
           env:
             - name: K8S_ENV
-              value: k8s-with-vault
+              value: k8s_vault
             - name: SPECIAL_K8S_SECRET
               valueFrom:
                 configMapKeyRef:

--- a/okteto/k8s/secret-challenge-deployment.yml
+++ b/okteto/k8s/secret-challenge-deployment.yml
@@ -28,7 +28,7 @@ spec:
         runAsGroup: 2000
         fsGroup: 2000
       containers:
-        - image: jeroenwillemsen/wrongsecrets:1.8.0RC4-no-vault
+        - image: jeroenwillemsen/wrongsecrets:1.7.2-no-vault
           name: secret-challenge
           imagePullPolicy: IfNotPresent
           securityContext:


### PR DESCRIPTION
 <!-- Thank you for submitting a pull request to the WrongSecrets app! See what makes a good PR at https://github.com/OWASP/wrongsecrets/blob/master/CONTRIBUTING.md-->

### What kind of changes does this PR include?

-   [x] Fixes or refactors
-   [ ] A new challenge
-   [ ] Additional documentation
-   [ ] Something else

#### Description

We found a few bugs in the 1.8.0RC4 code that are fixed with this branch:
- invalid k8s definitions for minikube
- invalid terratest urls

### Relations

<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
Closes #0000
--->

### References

<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Checklist:

-   [x] All the contributions made are solely the work of me and my co-authors
-   [x] I tested the changes in this PR (if applicable)
-   [ ] I added unit tests to ensure my change works (when change in Java or on front-end code)
-   [ ] I added UI tests to ensure my UI changes work (when change in the overall UI, not needed if just adding a challenge)
-   [ ] The PR passes pre-commit hooks and automated tests
