### PR TITLE
Bugfix: enable all challenges in cloud envs again

### DIFF
--- a/src/main/java/org/owasp/wrongsecrets/challenges/docker/Challenge32.java
+++ b/src/main/java/org/owasp/wrongsecrets/challenges/docker/Challenge32.java
@@ -13,7 +13,7 @@ import org.owasp.wrongsecrets.challenges.Spoiler;
 import org.springframework.stereotype.Component;
 
 /**
- * This is a challenge based on LLM where poeople need to extract the secret from
+ * This is a challenge based on LLM where people need to extract the secret from
  * https://https://gandalf.lakera.ai//
  */
 @Slf4j

--- a/src/main/resources/wrong-secrets-configuration.yaml
+++ b/src/main/resources/wrong-secrets-configuration.yaml
@@ -156,7 +156,7 @@ configurations:
           explanation: "explanations/challenge5.adoc"
           hint: "explanations/challenge5_hint.adoc"
           reason: "explanations/challenge5_reason.adoc"
-          environments: [ *k8s, *k8s_vault ]
+          environments: [ *k8s, *k8s_vault, *gcp, *azure, *aws ]
         - class-name: "org.owasp.wrongsecrets.challenges.kubernetes.Challenge5"
           explanation: "explanations/challenge5.adoc"
           hint: "explanations/challenge5_hint_limited.adoc"
@@ -174,7 +174,7 @@ configurations:
           explanation: "explanations/challenge6.adoc"
           hint: "explanations/challenge6_hint.adoc"
           reason: "explanations/challenge6_reason.adoc"
-          environments: [ *k8s, *k8s_vault ]
+          environments: [ *k8s, *k8s_vault, *gcp, *azure, *aws ]
         - class-name: "org.owasp.wrongsecrets.challenges.kubernetes.Challenge6"
           explanation: "explanations/challenge6.adoc"
           hint: "explanations/challenge6_hint_limited.adoc"
@@ -192,7 +192,7 @@ configurations:
           explanation: "explanations/challenge7.adoc"
           hint: "explanations/challenge7_hint.adoc"
           reason: "explanations/challenge7_reason.adoc"
-          environments: [ *k8s_vault ]
+          environments: [ *k8s_vault, *gcp, *aws, *azure ]
       difficulty: *expert
       category: *vault
       ctf:
@@ -292,7 +292,7 @@ configurations:
           explanation: "explanations/challenge12.adoc"
           hint: "explanations/challenge12_hint.adoc"
           reason: "explanations/challenge12_reason.adoc"
-          environments: *docker_envs
+          environments: *all_envs
       difficulty: *hard
       category: *docker_tech
       ctf:
@@ -305,7 +305,7 @@ configurations:
           explanation: "explanations/challenge13.adoc"
           hint: "explanations/challenge13_hint.adoc"
           reason: "explanations/challenge13_reason.adoc"
-          environments: *docker_envs
+          environments: *all_envs
       difficulty: *hard
       category: *ci_cd
       ctf:
@@ -318,7 +318,7 @@ configurations:
           explanation: "explanations/challenge14.adoc"
           hint: "explanations/challenge14_hint.adoc"
           reason: "explanations/challenge14_reason.adoc"
-          environments: *docker_envs
+          environments: *all_envs
       difficulty: *expert
       category: *password
       ctf:
@@ -331,7 +331,7 @@ configurations:
           explanation: "explanations/challenge15.adoc"
           hint: "explanations/challenge15_hint.adoc"
           reason: "explanations/challenge15_reason.adoc"
-          environments: *docker_envs
+          environments: *all_envs
       difficulty: *normal
       category: *git
       ctf:
@@ -345,7 +345,7 @@ configurations:
           hint: "explanations/challenge16_hint.adoc"
           reason: "explanations/challenge16_reason.adoc"
           ui-snippet: "challenges/challenge-16/challenge-16.snippet"
-          environments: *docker_envs
+          environments: *all_envs
       difficulty: *hard
       category: *front
       ctf:
@@ -358,7 +358,7 @@ configurations:
           explanation: "explanations/challenge17.adoc"
           hint: "explanations/challenge17_hint.adoc"
           reason: "explanations/challenge17_reason.adoc"
-          environments: *docker_envs
+          environments: *all_envs
       difficulty: *hard
       category: *docker_tech
       ctf:
@@ -371,7 +371,7 @@ configurations:
           explanation: "explanations/challenge18.adoc"
           hint: "explanations/challenge18_hint.adoc"
           reason: "explanations/challenge18_reason.adoc"
-          environments: *docker_envs
+          environments: *all_envs
       difficulty: *master
       category: *crypto
       ctf:
@@ -384,7 +384,7 @@ configurations:
           explanation: "explanations/challenge19.adoc"
           hint: "explanations/challenge19_hint.adoc"
           reason: "explanations/challenge19_reason.adoc"
-          environments: *docker_envs
+          environments: *all_envs
       difficulty: *expert
       category: *bin
       ctf:
@@ -397,7 +397,7 @@ configurations:
           explanation: "explanations/challenge20.adoc"
           hint: "explanations/challenge20_hint.adoc"
           reason: "explanations/challenge20_reason.adoc"
-          environments: *docker_envs
+          environments: *all_envs
       difficulty: *expert
       category: *bin
       ctf:
@@ -410,7 +410,7 @@ configurations:
           explanation: "explanations/challenge21.adoc"
           hint: "explanations/challenge21_hint.adoc"
           reason: "explanations/challenge21_reason.adoc"
-          environments: *docker_envs
+          environments: *all_envs
       difficulty: *master
       category: *bin
       ctf:
@@ -423,7 +423,7 @@ configurations:
           explanation: "explanations/challenge22.adoc"
           hint: "explanations/challenge22_hint.adoc"
           reason: "explanations/challenge22_reason.adoc"
-          environments: *docker_envs
+          environments: *all_envs
       difficulty: *master
       category: *bin
       ctf:
@@ -436,7 +436,7 @@ configurations:
           explanation: "explanations/challenge23.adoc"
           hint: "explanations/challenge23_hint.adoc"
           reason: "explanations/challenge23_reason.adoc"
-          environments: *docker_envs
+          environments: *all_envs
       difficulty: *easy
       category: *front
       ctf:
@@ -449,7 +449,7 @@ configurations:
           explanation: "explanations/challenge24.adoc"
           hint: "explanations/challenge24_hint.adoc"
           reason: "explanations/challenge24_reason.adoc"
-          environments: *docker_envs
+          environments: *all_envs
       difficulty: *normal
       category: *crypto
       ctf:
@@ -462,7 +462,7 @@ configurations:
           explanation: "explanations/challenge25.adoc"
           hint: "explanations/challenge25_hint.adoc"
           reason: "explanations/challenge25_reason.adoc"
-          environments: *docker_envs
+          environments: *all_envs
       difficulty: *normal
       category: *web3
       ctf:
@@ -475,7 +475,7 @@ configurations:
           explanation: "explanations/challenge26.adoc"
           hint: "explanations/challenge26_hint.adoc"
           reason: "explanations/challenge26_reason.adoc"
-          environments: *docker_envs
+          environments: *all_envs
       difficulty: *normal
       category: *web3
       ctf:
@@ -488,7 +488,7 @@ configurations:
           explanation: "explanations/challenge27.adoc"
           hint: "explanations/challenge27_hint.adoc"
           reason: "explanations/challenge27_reason.adoc"
-          environments: *docker_envs
+          environments: *all_envs
       difficulty: *normal
       category: *web3
       ctf:
@@ -501,7 +501,7 @@ configurations:
           explanation: "explanations/challenge28.adoc"
           hint: "explanations/challenge28_hint.adoc"
           reason: "explanations/challenge28_reason.adoc"
-          environments: *docker_envs
+          environments: *all_envs
       difficulty: *easy
       category: *doc
       ctf:
@@ -514,7 +514,7 @@ configurations:
           explanation: "explanations/challenge29.adoc"
           hint: "explanations/challenge29_hint.adoc"
           reason: "explanations/challenge29_reason.adoc"
-          environments: *docker_envs
+          environments: *all_envs
       difficulty: *easy
       category: *doc
       ctf:
@@ -528,7 +528,7 @@ configurations:
           hint: "explanations/challenge30_hint.adoc"
           reason: "explanations/challenge30_reason.adoc"
           ui-snippet: "challenges/challenge-30/challenge-30.snippet"
-          environments: *docker_envs
+          environments: *all_envs
       difficulty: *normal
       category: *front
       ctf:
@@ -541,7 +541,7 @@ configurations:
           explanation: "explanations/challenge31.adoc"
           hint: "explanations/challenge31_hint.adoc"
           reason: "explanations/challenge31_reason.adoc"
-          environments: *docker_envs
+          environments: *all_envs
       difficulty: *easy
       category: *front
       ctf:
@@ -554,7 +554,7 @@ configurations:
           explanation: "explanations/challenge32.adoc"
           hint: "explanations/challenge32_hint.adoc"
           reason: "explanations/challenge32_reason.adoc"
-          environments: *docker_envs
+          environments: *all_envs
       difficulty: *normal
       category: *ai
       ctf:
@@ -567,7 +567,7 @@ configurations:
           explanation: "explanations/challenge33.adoc"
           hint: "explanations/challenge33_hint.adoc"
           reason: "explanations/challenge33_reason.adoc"
-          environments: [ *k8s ]
+          environments: [ *k8s, *k8s_vault, *gcp, *azure, *aws ]
       difficulty: *normal
       category: *secrets
       ctf:
@@ -580,7 +580,7 @@ configurations:
           explanation: "explanations/challenge34.adoc"
           hint: "explanations/challenge34_hint.adoc"
           reason: "explanations/challenge34_reason.adoc"
-          environments: *docker_envs
+          environments: *all_envs
       difficulty: *normal
       category: *crypto
       ctf:
@@ -593,7 +593,7 @@ configurations:
           explanation: "explanations/challenge35.adoc"
           hint: "explanations/challenge35_hint.adoc"
           reason: "explanations/challenge35_reason.adoc"
-          environments: *docker_envs
+          environments: *all_envs
       difficulty: *easy
       category: *doc
       ctf:
@@ -606,7 +606,7 @@ configurations:
           explanation: "explanations/challenge36.adoc"
           hint: "explanations/challenge36_hint.adoc"
           reason: "explanations/challenge36_reason.adoc"
-          environments: *docker_envs
+          environments: *all_envs
       difficulty: *master
       category: *bin
       ctf:
@@ -619,7 +619,7 @@ configurations:
           explanation: "explanations/challenge37.adoc"
           hint: "explanations/challenge37_hint.adoc"
           reason: "explanations/challenge37_reason.adoc"
-          environments: *docker_envs
+          environments: *all_envs
       difficulty: *normal
       category: *ci_cd
       ctf:
@@ -632,7 +632,7 @@ configurations:
           explanation: "explanations/challenge38.adoc"
           hint: "explanations/challenge38_hint.adoc"
           reason: "explanations/challenge38_reason.adoc"
-          environments: *docker_envs
+          environments: *all_envs
       difficulty: *easy
       category: *git
       ctf:
@@ -645,7 +645,7 @@ configurations:
           explanation: "explanations/challenge39.adoc"
           hint: "explanations/challenge39_hint.adoc"
           reason: "explanations/challenge39_reason.adoc"
-          environments: *docker_envs
+          environments: *all_envs
       difficulty: *easy
       category: *crypto
       ctf:
@@ -658,7 +658,7 @@ configurations:
           explanation: "explanations/challenge40.adoc"
           hint: "explanations/challenge40_hint.adoc"
           reason: "explanations/challenge40_reason.adoc"
-          environments: *docker_envs
+          environments: *all_envs
       difficulty: *easy
       category: *crypto
       ctf:
@@ -671,7 +671,7 @@ configurations:
           explanation: "explanations/challenge41.adoc"
           hint: "explanations/challenge41_hint.adoc"
           reason: "explanations/challenge41_reason.adoc"
-          environments: *docker_envs
+          environments: *all_envs
       difficulty: *hard
       category: *crypto
       ctf:
@@ -684,7 +684,7 @@ configurations:
           explanation: "explanations/challenge42.adoc"
           hint: "explanations/challenge42_hint.adoc"
           reason: "explanations/challenge42_reason.adoc"
-          environments: *docker_envs
+          environments: *all_envs
       difficulty: *normal
       category: *logging
       ctf:

--- a/src/test/java/org/owasp/wrongsecrets/challenges/cloud/ChallengesControllerWithPresetCloudValuesTest.java
+++ b/src/test/java/org/owasp/wrongsecrets/challenges/cloud/ChallengesControllerWithPresetCloudValuesTest.java
@@ -1,0 +1,98 @@
+package org.owasp.wrongsecrets.challenges.cloud;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.owasp.wrongsecrets.Challenges;
+import org.owasp.wrongsecrets.WrongSecretsApplication;
+import org.owasp.wrongsecrets.challenges.cloud.challenge11.Challenge11Aws;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(
+    properties = {
+      "K8S_ENV=GCP",
+      "ctf_key=randomtextforkey",
+      "SPECIAL_K8S_SECRET=test5",
+      "SPECIAL_SPECIAL_K8S_SECRET=test6",
+      "vaultpassword=test7",
+      "secretmountpath=nothere",
+      "default_aws_value_challenge_9=ACTUAL_ANSWER_CHALLENGE9",
+      "default_aws_value_challenge_10=ACTUAL_ANSWER_CHALLENGE10",
+      "default_aws_value_challenge_11=ACTUAL_ANSWER_CHALLENGE_11"
+    },
+    classes = WrongSecretsApplication.class)
+@AutoConfigureMockMvc
+class ChallengesControllerWithPresetCloudValuesTest {
+
+  @Autowired private MockMvc mvc;
+  @Autowired private Challenges challenges;
+  @Autowired private Challenge11Aws challenge11;
+
+  @Test
+  void shouldSpoilExercises() throws Exception {
+    var firstChallenge = challenges.getChallengeDefinitions().getFirst();
+    mvc.perform(get("/spoil/%s".formatted(firstChallenge.name().shortName())))
+        .andExpect(status().isOk())
+        .andExpect(content().string(containsString("The first answer")));
+    mvc.perform(get("/spoil/challenge-5"))
+        .andExpect(status().isOk())
+        .andExpect(content().string(containsString("test5")));
+    mvc.perform(get("/spoil/challenge-6"))
+        .andExpect(status().isOk())
+        .andExpect(content().string(containsString("test6")));
+    mvc.perform(get("/spoil/challenge-9"))
+        .andExpect(status().isOk())
+        .andExpect(content().string(containsString("ACTUAL_ANSWER_CHALLENGE9")));
+  }
+
+  @Test
+  void shouldNotShowDisabledChallenge11() throws Exception {
+    var spoil = challenge11.spoiler().solution();
+
+    mvc.perform(
+            post("/challenge/challenge-11")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .param("solution", spoil)
+                .param("action", "submit")
+                .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(content().string(not(containsString("This challenge has been disabled."))));
+  }
+
+  @Test
+  void shouldEnableCloudExercises() throws Exception {
+    mvc.perform(get("/"))
+        .andExpect(status().isOk())
+        .andExpect(content().string(not(containsString("challenge-9_disabled-link"))))
+        .andExpect(content().string(not(containsString("challenge-10_disabled-link"))))
+        .andExpect(content().string(not(containsString("challenge-11_disabled-link"))));
+  }
+
+  @Test
+  void shouldEnableK8sExercises() throws Exception {
+    mvc.perform(get("/"))
+        .andExpect(status().isOk())
+        .andExpect(content().string(not(containsString("challenge-5_disabled-link"))))
+        .andExpect(content().string(not(containsString("challenge-6_disabled-link"))))
+        .andExpect(content().string(not(containsString("challenge-7_disabled-link"))));
+  }
+
+  @Test
+  void shouldEnableDockerExercises() throws Exception {
+    mvc.perform(get("/"))
+        .andExpect(status().isOk())
+        .andExpect(content().string(not(containsString("challenge-1_disabled-link"))))
+        .andExpect(content().string(not(containsString("challenge-2_disabled-link"))))
+        .andExpect(content().string(not(containsString("challenge-22_disabled-link"))));
+  }
+}

--- a/src/test/java/org/owasp/wrongsecrets/challenges/cloud/ChallengesControllerWithPresetCloudValuesTest.java
+++ b/src/test/java/org/owasp/wrongsecrets/challenges/cloud/ChallengesControllerWithPresetCloudValuesTest.java
@@ -73,7 +73,8 @@ class ChallengesControllerWithPresetCloudValuesTest {
         .andExpect(status().isOk())
         .andExpect(content().string(not(containsString("challenge-5_disabled-link"))))
         .andExpect(content().string(not(containsString("challenge-6_disabled-link"))))
-        .andExpect(content().string(not(containsString("challenge-7_disabled-link"))));
+        .andExpect(content().string(not(containsString("challenge-7_disabled-link"))))
+        .andExpect(content().string(not(containsString("challenge-33_disabled-link"))));
   }
 
   @Test


### PR DESCRIPTION
 <!-- Thank you for submitting a pull request to the WrongSecrets app! See what makes a good PR at https://github.com/OWASP/wrongsecrets/blob/master/CONTRIBUTING.md-->

### What kind of changes does this PR include?

-   [x] Fixes or refactors
-   [ ] A new challenge
-   [ ] Additional documentation
-   [ ] Something else

#### Description

Fixes that docker challenges and k8s challenges don't come up on GCP/AWS/Azure.

### Relations

Closes https://github.com/OWASP/wrongsecrets/issues/1130

### References

<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Checklist:

-   [x] All the contributions made are solely the work of me and my co-authors
-   [x] I tested the changes in this PR (if applicable)
-   [x] I added unit tests to ensure my change works (when change in Java or on front-end code)
-   [ ] I added UI tests to ensure my UI changes work (when change in the overall UI, not needed if just adding a challenge)
-   [x] The PR passes pre-commit hooks and automated tests
