### PR TITLE
feat: run Cypress test against pre-compiled HTML

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -565,6 +565,14 @@
         <artifactId>gatling-maven-plugin</artifactId>
         <version>${gatling-maven-plugin.version}</version>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.2</version>
+        <configuration>
+          <argLine>-Dspring.profiles.active=test,maven-test</argLine>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
During the build html files are generated based on ascii doc files. When we run the Cypress test in a Maven build we should test against these html files for the challenge text etc. This way we make sure the asciidoc plugin in Maven works.

The Cypress test running outside Maven still use the on-the-fly asciidoc generator. This way one can still directly see the changes in the challenge text when running the Cypress tests directly.

 Closes: gh-1139
