### PR TITLE
Issue 1193: update trufflehog command on the challenge 1 hint doc

### DIFF
--- a/src/main/resources/explanations/challenge1_hint.adoc
+++ b/src/main/resources/explanations/challenge1_hint.adoc
@@ -25,6 +25,7 @@ You can solve this challenge by the following steps:
 - Download trufflehog generic detector `wget https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/examples/generic.yml`.
 - Scan the files using `trufflehog filesystem --config=$PWD/generic.yml . | grep password` and the password will be in the output.
 
-5. Alternativel you can use the older Trufflehog 2:
+5. Alternative, you can use the older Trufflehog 2:
 - Have python and pip3 installed, and run `pip3 install trufflehog` to install Trufflehog 2.
 - Scan the files using `trufflehog . | grep password` and the password will be in the output.
+- Please note that Trufflehog 2 was released [> 5 years ago](https://github.com/trufflesecurity/trufflehog/tags?after=v3.0.0) and no longer [maintained](https://github.com/trufflesecurity/trufflehog/issues/2328).

--- a/src/main/resources/explanations/challenge1_hint.adoc
+++ b/src/main/resources/explanations/challenge1_hint.adoc
@@ -24,3 +24,7 @@ You can solve this challenge by the following steps:
 - Follow these instructions to download the https://github.com/trufflesecurity/trufflehog/blob/4afc224c635d10e732119f715f93788af1502ce4/examples/README.md[generic detector] file
 - Download trufflehog generic detector `wget https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/examples/generic.yml`.
 - Scan the files using `trufflehog filesystem --config=$PWD/generic.yml . | grep password` and the password will be in the output.
+
+5. Alternativel you can use the older Trufflehog 2:
+- Have python and pip3 installed, and run `pip3 install trufflehog` to install Trufflehog 2.
+- Scan the files using `trufflehog . | grep password` and the password will be in the output.

--- a/src/main/resources/explanations/challenge1_hint.adoc
+++ b/src/main/resources/explanations/challenge1_hint.adoc
@@ -21,6 +21,6 @@ You can solve this challenge by the following steps:
 4. You can scan the repository with https://github.com/trufflesecurity/trufflehog[*Trufflehog*].
 - Clone the repo with `git clone https://github.com/OWASP/wrongsecrets`.
 - Follow the instructions https://github.com/trufflesecurity/trufflehog[here] to install Trufflehog.
-- How to download trufflehog https://github.com/trufflesecurity/trufflehog/blob/4afc224c635d10e732119f715f93788af1502ce4/examples/README.md[generic detector] file
+- Follow these instructions to download the https://github.com/trufflesecurity/trufflehog/blob/4afc224c635d10e732119f715f93788af1502ce4/examples/README.md[generic detector] file
 - Download trufflehog generic detector `wget https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/examples/generic.yml`.
 - Scan the files using `trufflehog filesystem --config=$PWD/generic.yml . | grep password` and the password will be in the output.

--- a/src/main/resources/explanations/challenge1_hint.adoc
+++ b/src/main/resources/explanations/challenge1_hint.adoc
@@ -21,4 +21,6 @@ You can solve this challenge by the following steps:
 4. You can scan the repository with https://github.com/trufflesecurity/trufflehog[*Trufflehog*].
 - Clone the repo with `git clone https://github.com/OWASP/wrongsecrets`.
 - Follow the instructions https://github.com/trufflesecurity/trufflehog[here] to install Trufflehog.
-- Scan the files using `trufflehog filesystem --config=$TRUFFLEHOG_DIR/examples/generic.yml . | grep password` and the password will be in the output.
+- How to download trufflehog https://github.com/trufflesecurity/trufflehog/blob/4afc224c635d10e732119f715f93788af1502ce4/examples/README.md[generic detector] file
+- Download trufflehog generic detector `wget https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/examples/generic.yml`.
+- Scan the files using `trufflehog filesystem --config=$PWD/generic.yml . | grep password` and the password will be in the output.

--- a/src/main/resources/explanations/challenge1_hint.adoc
+++ b/src/main/resources/explanations/challenge1_hint.adoc
@@ -21,4 +21,4 @@ You can solve this challenge by the following steps:
 4. You can scan the repository with https://github.com/trufflesecurity/trufflehog[*Trufflehog*].
 - Clone the repo with `git clone https://github.com/OWASP/wrongsecrets`.
 - Follow the instructions https://github.com/trufflesecurity/trufflehog[here] to install Trufflehog.
-- Scan the files using `trufflehog . | grep password` and the password will be in the output.
+- Scan the files using `trufflehog filesystem --config=$TRUFFLEHOG_DIR/examples/generic.yml . | grep password` and the password will be in the output.


### PR DESCRIPTION
### What kind of changes does this PR include?

-   [ ] Fixes or refactors
-   [ ] A new challenge
-   [x] Additional documentation
-   [ ] Something else

#### Description

because with previous command it's not showing the result. Trufflehog needs to scan the filesystem and use generic detector from the example.

Note: it's suggested to use the latest Trufflehog version. When this
commit was made, the latest version is: 3.63.10

### Relations

Closes #1193 

### References

<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Checklist:

-   [x] All the contributions made are solely the work of me and my co-authors