### PR TITLE
Install libstdc++ to fix issue 1279

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:21.0.2-alpine
+FROM amazoncorretto:22.0.0-alpine
 
 ARG argBasedPassword="default"
 ARG argBasedVersion="1.8.4"
@@ -14,6 +14,8 @@ ENV SPRINGDOC_DOC=false
 RUN echo "2vars"
 RUN echo "$ARG_BASED_PASSWORD"
 RUN echo "$argBasedPassword"
+
+RUN apk add --no-cache libstdc++
 
 # RUN useradd -u 2000 -m wrongsecrets
 RUN adduser -u 2000 -D wrongsecrets


### PR DESCRIPTION
 <!-- Thank you for submitting a pull request to the WrongSecrets app! See what makes a good PR at https://github.com/OWASP/wrongsecrets/blob/master/CONTRIBUTING.md-->

### What kind of changes does this PR include?

-   [x] Fixes or refactors
-   [ ] A new challenge
-   [ ] Additional documentation
-   [ ] Something else

#### Description

<!---
Please provide a helpful summary of what change this pull request will introduce.
--->

Install `libstc++` which missing from base image and C++ challenges rely on.

Closes [1279](https://github.com/OWASP/wrongsecrets/issues/1279)

### References

<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Checklist:

-   [x] All the contributions made are solely the work of me and my co-authors
-   [x] I tested the changes in this PR (if applicable)
-   [ ] I added unit tests to ensure my change works (when change in Java or on front-end code)
-   [ ] I added UI tests to ensure my UI changes work (when change in the overall UI, not needed if just adding a challenge)
-   [ ] The PR passes pre-commit hooks and automated tests
