### PR TITLE
fix: add terratest for challenge disabled

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,8 +8,8 @@ on:
 
 env:
   TF_DOCS_VERSION: v0.16.0
-  TFSEC_VERSION: v1.27.6
-  TFLINT_VERSION: v0.41.0
+  TFSEC_VERSION: v1.28.6
+  TFLINT_VERSION: v0.47.0
 permissions:
   contents: read
 jobs:
@@ -22,7 +22,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.11"
       - name: Format python code with black
         uses: psf/black@stable
       - uses: actions/setup-node@v4
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.1.7
+          terraform_version: 1.7.4
       - name: Setup TFLint
         uses: terraform-linters/setup-tflint@v4
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,12 +46,12 @@ repos:
       - id: maven
         args: [ 'clean compile' ]
       - id: maven-spotless-apply
-  - repo: https://github.com/eslint/eslint
-    rev: v9.3.0
-    hooks:
-      - id: eslint
-        args:
-          - "--fix"
+  # - repo: https://github.com/eslint/eslint
+  #   rev: v9.3.0
+  #   hooks:
+  #     - id: eslint
+  #       args:
+  #         - "--fix"
   - repo: https://github.com/psf/black
     rev: 24.4.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         exclude: ^(src/test/resources/yourkey.txt|src/test/resources/secondkey.txt)
       - id: trailing-whitespace
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.89.0
+    rev: v1.89.1
     hooks:
       - id: terraform_fmt
       - id: terraform_tflint
@@ -36,7 +36,7 @@ repos:
           - "--args=--only=terraform_workspace_remote"
       - id: terraform_docs
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v9.15.0
+    rev: v9.16.0
     hooks:
       - id: commitlint
         stages: [commit-msg]
@@ -46,14 +46,14 @@ repos:
       - id: maven
         args: [ 'clean compile' ]
       - id: maven-spotless-apply
-  # - repo: https://github.com/eslint/eslint
-  #   rev: v9.0.0
-  #   hooks:
-  #     - id: eslint
-  #       args:
-  #         - "--fix"
+  - repo: https://github.com/eslint/eslint
+    rev: v9.3.0
+    hooks:
+      - id: eslint
+        args:
+          - "--fix"
   - repo: https://github.com/psf/black
-    rev: 24.4.0
+    rev: 24.4.2
     hooks:
     - id: black
-      language_version: python3.10
+      language_version: python3.11

--- a/aws/wrongsecrets_aws_test.go
+++ b/aws/wrongsecrets_aws_test.go
@@ -39,6 +39,8 @@ func TestTerraformWrongSecretsAWS(t *testing.T) {
 	// Also run the cleanup script to remove the ALB resources
 	defer terraform.Destroy(t, terraformOptions)
 	cleanupCommand := []string{LB_SCRIPT}
+	defer log.Printf("Setup completed, now waiting 30 seconds to get all settled in")
+	defer time.Sleep(time.Duration(30) * time.Second)
 	defer execute(LB_SCRIPT, cleanupCommand)
 
 	// Run `terraform init` and `terraform apply`. Fail the test if there are any errors.

--- a/aws/wrongsecrets_aws_test.go
+++ b/aws/wrongsecrets_aws_test.go
@@ -1,98 +1,112 @@
 package test
 
 import (
-    "fmt"
-    "log"
-    "os"
-    "os/exec"
-    "strings"
-    "testing"
-    "time"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
 
-    http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
+	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
 
-    "github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/gruntwork-io/terratest/modules/terraform"
 )
 
 var START_SCRIPT = "./k8s-vault-aws-start.sh"
 var LB_SCRIPT = "./k8s-aws-alb-script.sh"
 
 func TestTerraformWrongSecretsAWS(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 
-    // Construct the terraform options with default retryable errors to handle the most common
-    // retryable errors in terraform testing.
-    terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-        // The path to where our Terraform code is located
-        TerraformDir: "../aws",
-        Vars: map[string]interface{}{
-            "region": "eu-west-1",
-            "tags": map[string]string{
-                "Environment": "test",
-                "Application": "wrongsecrets",
-                "CreatedBy":   "Terratest",
-            },
-        },
-    })
+	// Construct the terraform options with default retryable errors to handle the most common
+	// retryable errors in terraform testing.
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		// The path to where our Terraform code is located
+		TerraformDir: "../aws",
+		Vars: map[string]interface{}{
+			"region": "eu-west-1",
+			"tags": map[string]string{
+				"Environment": "test",
+				"Application": "wrongsecrets",
+				"CreatedBy":   "Terratest",
+			},
+		},
+	})
 
-    // At the end of the test, run `terraform destroy` to clean up any resources that were created.
-    // Also run the cleanup script to remove the ALB resources
-    defer terraform.Destroy(t, terraformOptions)
-    cleanupCommand := []string{LB_SCRIPT}
-    defer execute(LB_SCRIPT, cleanupCommand)
+	// At the end of the test, run `terraform destroy` to clean up any resources that were created.
+	// Also run the cleanup script to remove the ALB resources
+	defer terraform.Destroy(t, terraformOptions)
+	cleanupCommand := []string{LB_SCRIPT}
+	defer execute(LB_SCRIPT, cleanupCommand)
 
-    // Run `terraform init` and `terraform apply`. Fail the test if there are any errors.
-    terraform.InitAndApply(t, terraformOptions)
+	// Run `terraform init` and `terraform apply`. Fail the test if there are any errors.
+	terraform.InitAndApply(t, terraformOptions)
 
-    // Run `terraform output` to get the endpoint of the cluster
-    // wrongsecretsClusterEndpoint := terraform.Output(t, terraformOptions, "cluster_endpoint")
+	// Run `terraform output` to get the endpoint of the cluster
+	// wrongsecretsClusterEndpoint := terraform.Output(t, terraformOptions, "cluster_endpoint")
 
-    command := []string{START_SCRIPT}
-    execute(START_SCRIPT, command)
+	command := []string{START_SCRIPT}
+	execute(START_SCRIPT, command)
 
-    // Make an HTTP request to the instance and make sure we get back a 200 OK with the body "Hello, World!"
-    challenge9 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-9")
-    challenge10 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-10")
-    challenge11 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-11")
+	// Make an HTTP request to the instance and make sure we get back a 200 OK with the body "Hello, World!"
+	challenge9 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-9")
+	challenge10 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-10")
+	challenge11 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-11")
+	main := fmt.Sprintf("http://%s:8080", "localhost")
 
-    // Make an HTTP request to the instance and make sure we get back a 200 OK and don't see expected string. Retries for a while.
-    http_helper.HttpGetWithRetryWithCustomValidation(t, challenge9, nil, 30, 5*time.Second, validateResponse)
-    http_helper.HttpGetWithRetryWithCustomValidation(t, challenge10, nil, 30, 5*time.Second, validateResponse)
-    http_helper.HttpGetWithRetryWithCustomValidation(t, challenge11, nil, 30, 5*time.Second, validateResponse)
+	// Make sure all challenges are enabled
+	http_helper.HttpGetWithCustomValidation(t, main, nil, validateChallengesEnabled)
+
+	// Make an HTTP request to the instance and make sure we get back a 200 OK and don't see expected string. Retries for a while.
+	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge9, nil, 30, 5*time.Second, validateCloudChallengeResponse)
+	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge10, nil, 30, 5*time.Second, validateCloudChallengeResponse)
+	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge11, nil, 30, 5*time.Second, validateCloudChallengeResponse)
 }
 
-func validateResponse(statusCode int, body string) bool {
-    // body should not contain if_you_see_this_please_use_AWS_Setup
-    if strings.Contains(body, "if_you_see_this_please_use_AWS_Setup") {
-        log.Printf("Found if_you_see_this_please_use_AWS_Setup in response body")
-        return false
-    }
-    // body should not contain please_use_supported_cloud_env
-    if strings.Contains(body, "please_use_supported_cloud_env") {
-        log.Printf("Found please_use_supported_cloud_env in response body")
-        return false
-    }
-    return statusCode == 200
+func validateCloudChallengeResponse(statusCode int, body string) bool {
+	// body should not contain if_you_see_this_please_use_AWS_Setup
+	if strings.Contains(body, "if_you_see_this_please_use_AWS_Setup") {
+		log.Printf("Found if_you_see_this_please_use_AWS_Setup in response body")
+		return false
+	}
+	// body should not contain please_use_supported_cloud_env
+	if strings.Contains(body, "please_use_supported_cloud_env") {
+		log.Printf("Found please_use_supported_cloud_env in response body")
+		return false
+	}
+	return statusCode == 200
+}
+
+func validateChallengesEnabled(statusCode int, body string) bool {
+	// body should not contain class="disabled"
+	if strings.Contains(body, "class=\"disabled\"") {
+		log.Printf("Found class=\"disabled\" in response body")
+		return false
+	}
+
+	return statusCode == 200
 }
 
 func execute(script string, command []string) (bool, error) {
 
-    cmd := &exec.Cmd{
-        Path:   script,
-        Args:   command,
-        Stdout: os.Stdout,
-        Stderr: os.Stderr,
-    }
+	cmd := &exec.Cmd{
+		Path:   script,
+		Args:   command,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
 
-    err := cmd.Start()
-    if err != nil {
-        return false, err
-    }
+	err := cmd.Start()
+	if err != nil {
+		return false, err
+	}
 
-    err = cmd.Wait()
-    if err != nil {
-        return false, err
-    }
+	err = cmd.Wait()
+	if err != nil {
+		return false, err
+	}
 
-    return true, nil
+	return true, nil
 }

--- a/aws/wrongsecrets_aws_test.go
+++ b/aws/wrongsecrets_aws_test.go
@@ -37,11 +37,11 @@ func TestTerraformWrongSecretsAWS(t *testing.T) {
 
 	// At the end of the test, run `terraform destroy` to clean up any resources that were created.
 	// Also run the cleanup script to remove the ALB resources
-	defer terraform.Destroy(t, terraformOptions)
 	cleanupCommand := []string{LB_SCRIPT}
+	defer execute(LB_SCRIPT, cleanupCommand)
 	defer log.Printf("Setup completed, now waiting 30 seconds to get all settled in")
 	defer time.Sleep(time.Duration(30) * time.Second)
-	defer execute(LB_SCRIPT, cleanupCommand)
+	defer terraform.Destroy(t, terraformOptions)
 
 	// Run `terraform init` and `terraform apply`. Fail the test if there are any errors.
 	terraform.InitAndApply(t, terraformOptions)

--- a/azure/k8s-vault-azure-start.sh
+++ b/azure/k8s-vault-azure-start.sh
@@ -93,7 +93,7 @@ echo "Apply secretsmanager storage volume"
 kubectl apply -f./k8s/secret-volume.yml
 
 envsubst <./k8s/pod-id.yml.tpl >./k8s/pod-id.yml
-envsubst <./k8s/secret-challenge-vault-deployment.yml.tpl >./k8s/secret-challenge-vault-deployment.yml
+envsubst '${AZ_VAULT_URI},${AZ_POD_CLIENT_ID}' <./k8s/secret-challenge-vault-deployment.yml.tpl >./k8s/secret-challenge-vault-deployment.yml
 
 kubectl apply -f./k8s/pod-id.yml
 

--- a/azure/k8s/secret-challenge-vault-deployment.yml.tpl
+++ b/azure/k8s/secret-challenge-vault-deployment.yml.tpl
@@ -48,6 +48,8 @@ spec:
         runAsUser: 2000
         runAsGroup: 2000
         fsGroup: 2000
+        seccompProfile:
+            type: RuntimeDefault
       serviceAccountName: vault
       volumes:
         - name: 'ephemeral'

--- a/azure/k8s/secret-challenge-vault-deployment.yml.tpl
+++ b/azure/k8s/secret-challenge-vault-deployment.yml.tpl
@@ -59,7 +59,7 @@ spec:
             volumeAttributes:
               secretProviderClass: "azure-wrongsecrets-vault"
       containers:
-        - image: jeroenwillemsen/wrongsecrets:4-k8s-vault
+        - image: jeroenwillemsen/wrongsecrets:1.8.6A4-k8s-vault
           imagePullPolicy: IfNotPresent
           name: secret-challenge
           command: ["/bin/sh"]

--- a/azure/wrongsecrets_azure_test.go
+++ b/azure/wrongsecrets_azure_test.go
@@ -42,8 +42,8 @@ func TestTerraformWrongSecretsAzure(t *testing.T) {
 		START_SCRIPT,
 	}
 	execute(START_SCRIPT, command)
-	log.Printf("Setup completed, now waiting 30 seconds to get all settled in")
-	time.Sleep(time.Duration(30) * time.Second)
+	log.Printf("Setup completed, now waiting 40 seconds to get all settled in")
+	time.Sleep(time.Duration(40) * time.Second)
 	// Make an HTTP request to the instance and make sure we get back a 200 OK with the body "Hello, World!"
 	challenge9 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-9")
 	challenge10 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-10")

--- a/azure/wrongsecrets_azure_test.go
+++ b/azure/wrongsecrets_azure_test.go
@@ -42,7 +42,8 @@ func TestTerraformWrongSecretsAzure(t *testing.T) {
 		START_SCRIPT,
 	}
 	execute(START_SCRIPT, command)
-
+	log.Printf("Setup completed, now waiting 30 seconds to get all settled in")
+	time.Sleep(time.Duration(30) * time.Second)
 	// Make an HTTP request to the instance and make sure we get back a 200 OK with the body "Hello, World!"
 	challenge9 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-9")
 	challenge10 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-10")

--- a/azure/wrongsecrets_azure_test.go
+++ b/azure/wrongsecrets_azure_test.go
@@ -1,91 +1,105 @@
 package test
 
 import (
-    "fmt"
-    "log"
-    "os"
-    "os/exec"
-    "strings"
-    "testing"
-    "time"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
 
-    http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
+	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
 
-    "github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/gruntwork-io/terratest/modules/terraform"
 )
 
 var START_SCRIPT = "./k8s-vault-azure-start.sh"
 
 func TestTerraformWrongSecretsAzure(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 
-    // Construct the terraform options with default retryable errors to handle the most common
-    // retryable errors in terraform testing.
-    terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-        // The path to where our Terraform code is located
-        TerraformDir: "../azure",
-        Vars: map[string]interface{}{
-            "region": "East US",
-        },
-    })
+	// Construct the terraform options with default retryable errors to handle the most common
+	// retryable errors in terraform testing.
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		// The path to where our Terraform code is located
+		TerraformDir: "../azure",
+		Vars: map[string]interface{}{
+			"region": "East US",
+		},
+	})
 
-    // At the end of the test, run `terraform destroy` to clean up any resources that were created.
-    defer terraform.Destroy(t, terraformOptions)
+	// At the end of the test, run `terraform destroy` to clean up any resources that were created.
+	defer terraform.Destroy(t, terraformOptions)
 
-    // Run `terraform init` and `terraform apply`. Fail the test if there are any errors.
-    terraform.InitAndApply(t, terraformOptions)
+	// Run `terraform init` and `terraform apply`. Fail the test if there are any errors.
+	terraform.InitAndApply(t, terraformOptions)
 
-    // Run `terraform output` to get the endpoint of the cluster
-    // wrongsecretsClusterEndpoint := terraform.Output(t, terraformOptions, "cluster_endpoint")
+	// Run `terraform output` to get the endpoint of the cluster
+	// wrongsecretsClusterEndpoint := terraform.Output(t, terraformOptions, "cluster_endpoint")
 
-    command := []string{
-        START_SCRIPT,
-    }
-    execute(START_SCRIPT, command)
+	command := []string{
+		START_SCRIPT,
+	}
+	execute(START_SCRIPT, command)
 
-    // Make an HTTP request to the instance and make sure we get back a 200 OK with the body "Hello, World!"
-    challenge9 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-9")
-    challenge10 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-10")
-    challenge11 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-11")
+	// Make an HTTP request to the instance and make sure we get back a 200 OK with the body "Hello, World!"
+	challenge9 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-9")
+	challenge10 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-10")
+	challenge11 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-11")
+	main := fmt.Sprintf("http://%s:8080", "localhost")
 
-    // Make an HTTP request to the instance and make sure we get back a 200 OK and don't see expected string. Retries for a while.
-    http_helper.HttpGetWithRetryWithCustomValidation(t, challenge9, nil, 30, 5*time.Second, validateResponse)
-    http_helper.HttpGetWithRetryWithCustomValidation(t, challenge10, nil, 30, 5*time.Second, validateResponse)
-    http_helper.HttpGetWithRetryWithCustomValidation(t, challenge11, nil, 30, 5*time.Second, validateResponse)
+	// Make sure all challenges are enabled
+	http_helper.HttpGetWithCustomValidation(t, main, nil, validateChallengesEnabled)
+
+	// Make an HTTP request to the instance and make sure we get back a 200 OK and don't see expected string. Retries for a while.
+	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge9, nil, 30, 5*time.Second, validateCloudChallengeResponse)
+	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge10, nil, 30, 5*time.Second, validateCloudChallengeResponse)
+	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge11, nil, 30, 5*time.Second, validateCloudChallengeResponse)
 }
 
-func validateResponse(statusCode int, body string) bool {
-    // body should not contain if_you_see_this_please_use_AWS_Setup
-    if strings.Contains(body, "if_you_see_this_please_use_AWS_Setup") {
-        log.Printf("Found if_you_see_this_please_use_AWS_Setup in response body")
-        return false
-    }
-    // body should not contain please_use_supported_cloud_env
-    if strings.Contains(body, "please_use_supported_cloud_env") {
-        log.Printf("Found please_use_supported_cloud_env in response body")
-        return false
-    }
-    return statusCode == 200
+func validateCloudChallengeResponse(statusCode int, body string) bool {
+	// body should not contain if_you_see_this_please_use_AWS_Setup
+	if strings.Contains(body, "if_you_see_this_please_use_AWS_Setup") {
+		log.Printf("Found if_you_see_this_please_use_AWS_Setup in response body")
+		return false
+	}
+	// body should not contain please_use_supported_cloud_env
+	if strings.Contains(body, "please_use_supported_cloud_env") {
+		log.Printf("Found please_use_supported_cloud_env in response body")
+		return false
+	}
+	return statusCode == 200
+}
+
+func validateChallengesEnabled(statusCode int, body string) bool {
+	// body should not contain class="disabled"
+	if strings.Contains(body, "class=\"disabled\"") {
+		log.Printf("Found class=\"disabled\" in response body")
+		return false
+	}
+
+	return statusCode == 200
 }
 
 func execute(script string, command []string) (bool, error) {
 
-    cmd := &exec.Cmd{
-        Path:   script,
-        Args:   command,
-        Stdout: os.Stdout,
-        Stderr: os.Stderr,
-    }
+	cmd := &exec.Cmd{
+		Path:   script,
+		Args:   command,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
 
-    err := cmd.Start()
-    if err != nil {
-        return false, err
-    }
+	err := cmd.Start()
+	if err != nil {
+		return false, err
+	}
 
-    err = cmd.Wait()
-    if err != nil {
-        return false, err
-    }
+	err = cmd.Wait()
+	if err != nil {
+		return false, err
+	}
 
-    return true, nil
+	return true, nil
 }

--- a/gcp/k8s-vault-gcp-start.sh
+++ b/gcp/k8s-vault-gcp-start.sh
@@ -75,7 +75,7 @@ kubectl annotate serviceaccount \
   --namespace default default \
   "iam.gke.io/gcp-service-account=wrongsecrets-workload-sa@${GCP_PROJECT}.iam.gserviceaccount.com"
 
-envsubst <./k8s/secret-challenge-vault-deployment.yml.tpl >./k8s/secret-challenge-vault-deployment.yml
+envsubst '${GCP_PROJECT}' <./k8s/secret-challenge-vault-deployment.yml.tpl >./k8s/secret-challenge-vault-deployment.yml
 
 source ../scripts/apply-and-portforward.sh
 

--- a/gcp/k8s/secret-challenge-vault-deployment.yml.tpl
+++ b/gcp/k8s/secret-challenge-vault-deployment.yml.tpl
@@ -45,6 +45,8 @@ spec:
         runAsUser: 2000
         runAsGroup: 2000
         fsGroup: 2000
+        seccompProfile:
+            type: RuntimeDefault
       serviceAccountName: vault
       volumes:
         - name: 'ephemeral'

--- a/gcp/k8s/secret-challenge-vault-deployment.yml.tpl
+++ b/gcp/k8s/secret-challenge-vault-deployment.yml.tpl
@@ -27,8 +27,8 @@ spec:
         vault.hashicorp.com/agent-inject-secret-challenge46: "secret/data/injected"
         vault.hashicorp.com/agent-inject-template-challenge46: |
           {{ with secret "/secret/data/injected" }}
-            {{ range $k, $v := .Data.data }}
-              {{ printf "echo %s=%s" $k $v }}
+            {{ range $key, $value := .Data.data }}
+              {{ printf "echo %s=%s" $key $value }}
             {{ end }}
           {{ end }}
         vault.hashicorp.com/agent-inject-secret-challenge47: "secret/data/codified"

--- a/gcp/wrongsecrets_gcp_test.go
+++ b/gcp/wrongsecrets_gcp_test.go
@@ -1,92 +1,106 @@
 package test
 
 import (
-    "fmt"
-    "log"
-    "os"
-    "os/exec"
-    "strings"
-    "testing"
-    "time"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
 
-    http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
+	http_helper "github.com/gruntwork-io/terratest/modules/http-helper"
 
-    "github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/gruntwork-io/terratest/modules/terraform"
 )
 
 var START_SCRIPT = "./k8s-vault-gcp-start.sh"
 
 func TestTerraformWrongSecretsGCP(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 
-    // Construct the terraform options with default retryable errors to handle the most common
-    // retryable errors in terraform testing.
-    terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
-        // The path to where our Terraform code is located
-        TerraformDir: "../gcp",
-        Vars: map[string]interface{}{
-            "region":     "europe-west4",
-            "project_id": "owasp-wrongsecrets",
-        },
-    })
+	// Construct the terraform options with default retryable errors to handle the most common
+	// retryable errors in terraform testing.
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		// The path to where our Terraform code is located
+		TerraformDir: "../gcp",
+		Vars: map[string]interface{}{
+			"region":     "europe-west4",
+			"project_id": "owasp-wrongsecrets",
+		},
+	})
 
-    // At the end of the test, run `terraform destroy` to clean up any resources that were created.
-    defer terraform.Destroy(t, terraformOptions)
+	// At the end of the test, run `terraform destroy` to clean up any resources that were created.
+	defer terraform.Destroy(t, terraformOptions)
 
-    // Run `terraform init` and `terraform apply`. Fail the test if there are any errors.
-    terraform.InitAndApply(t, terraformOptions)
+	// Run `terraform init` and `terraform apply`. Fail the test if there are any errors.
+	terraform.InitAndApply(t, terraformOptions)
 
-    // Run `terraform output` to get the endpoint of the cluster
-    // wrongsecretsClusterEndpoint := terraform.Output(t, terraformOptions, "cluster_endpoint")
+	// Run `terraform output` to get the endpoint of the cluster
+	// wrongsecretsClusterEndpoint := terraform.Output(t, terraformOptions, "cluster_endpoint")
 
-    command := []string{
-        START_SCRIPT,
-    }
-    execute(START_SCRIPT, command)
+	command := []string{
+		START_SCRIPT,
+	}
+	execute(START_SCRIPT, command)
 
-    // Make an HTTP request to the instance and make sure we get back a 200 OK with the body "Hello, World!"
-    challenge9 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-9")
-    challenge10 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-10")
-    challenge11 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-11")
+	// Make an HTTP request to the instance and make sure we get back a 200 OK with the body "Hello, World!"
+	challenge9 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-9")
+	challenge10 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-10")
+	challenge11 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-11")
+	main := fmt.Sprintf("http://%s:8080", "localhost")
 
-    // Make an HTTP request to the instance and make sure we get back a 200 OK and don't see expected string. Retries for a while.
-    http_helper.HttpGetWithRetryWithCustomValidation(t, challenge9, nil, 30, 5*time.Second, validateResponse)
-    http_helper.HttpGetWithRetryWithCustomValidation(t, challenge10, nil, 30, 5*time.Second, validateResponse)
-    http_helper.HttpGetWithRetryWithCustomValidation(t, challenge11, nil, 30, 5*time.Second, validateResponse)
+	// Make sure all challenges are enabled
+	http_helper.HttpGetWithCustomValidation(t, main, nil, validateChallengesEnabled)
+
+	// Make an HTTP request to the instance and make sure we get back a 200 OK and don't see expected string. Retries for a while.
+	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge9, nil, 30, 5*time.Second, validateCloudChallengeResponse)
+	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge10, nil, 30, 5*time.Second, validateCloudChallengeResponse)
+	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge11, nil, 30, 5*time.Second, validateCloudChallengeResponse)
 }
 
-func validateResponse(statusCode int, body string) bool {
-    // body should not contain if_you_see_this_please_use_AWS_Setup
-    if strings.Contains(body, "if_you_see_this_please_use_AWS_Setup") {
-        log.Printf("Found if_you_see_this_please_use_AWS_Setup in response body")
-        return false
-    }
-    // body should not contain please_use_supported_cloud_env
-    if strings.Contains(body, "please_use_supported_cloud_env") {
-        log.Printf("Found please_use_supported_cloud_env in response body")
-        return false
-    }
-    return statusCode == 200
+func validateCloudChallengeResponse(statusCode int, body string) bool {
+	// body should not contain if_you_see_this_please_use_AWS_Setup
+	if strings.Contains(body, "if_you_see_this_please_use_AWS_Setup") {
+		log.Printf("Found if_you_see_this_please_use_AWS_Setup in response body")
+		return false
+	}
+	// body should not contain please_use_supported_cloud_env
+	if strings.Contains(body, "please_use_supported_cloud_env") {
+		log.Printf("Found please_use_supported_cloud_env in response body")
+		return false
+	}
+	return statusCode == 200
+}
+
+func validateChallengesEnabled(statusCode int, body string) bool {
+	// body should not contain class="disabled"
+	if strings.Contains(body, "class=\"disabled\"") {
+		log.Printf("Found class=\"disabled\" in response body")
+		return false
+	}
+
+	return statusCode == 200
 }
 
 func execute(script string, command []string) (bool, error) {
 
-    cmd := &exec.Cmd{
-        Path:   script,
-        Args:   command,
-        Stdout: os.Stdout,
-        Stderr: os.Stderr,
-    }
+	cmd := &exec.Cmd{
+		Path:   script,
+		Args:   command,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
 
-    err := cmd.Start()
-    if err != nil {
-        return false, err
-    }
+	err := cmd.Start()
+	if err != nil {
+		return false, err
+	}
 
-    err = cmd.Wait()
-    if err != nil {
-        return false, err
-    }
+	err = cmd.Wait()
+	if err != nil {
+		return false, err
+	}
 
-    return true, nil
+	return true, nil
 }

--- a/gcp/wrongsecrets_gcp_test.go
+++ b/gcp/wrongsecrets_gcp_test.go
@@ -43,7 +43,8 @@ func TestTerraformWrongSecretsGCP(t *testing.T) {
 		START_SCRIPT,
 	}
 	execute(START_SCRIPT, command)
-
+	log.Printf("Setup completed, now waiting 40 seconds to get all settled in")
+	time.Sleep(time.Duration(40) * time.Second)
 	// Make an HTTP request to the instance and make sure we get back a 200 OK with the body "Hello, World!"
 	challenge9 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-9")
 	challenge10 := fmt.Sprintf("http://%s:8080/%s", "localhost", "spoil/challenge-10")


### PR DESCRIPTION
 <!-- Thank you for submitting a pull request to the WrongSecrets app! See what makes a good PR at https://github.com/OWASP/wrongsecrets/blob/master/CONTRIBUTING.md-->

### What kind of changes does this PR include?

-   [ ] Fixes or refactors
-   [ ] A new challenge
-   [ ] Additional documentation
-   [x] Something else

#### Description

Extend terratest to make sure no challenges are disabled in cloud environments.

### Relations

Closes #1132 
Closes #1411 

### Checklist:

-   [x] All the contributions made are solely the work of me and my co-authors
-   [x] I tested the changes in this PR (if applicable)
-   [x] I added unit tests to ensure my change works (when change in Java or on front-end code)
-   [ ] I added UI tests to ensure my UI changes work (when change in the overall UI, not needed if just adding a challenge)
-   [x] The PR passes pre-commit hooks and automated tests
