### PR TITLE
disable vault challenges in ctf mode for now, and add missing spoiler…

### DIFF
--- a/src/main/resources/wrong-secrets-configuration.yaml
+++ b/src/main/resources/wrong-secrets-configuration.yaml
@@ -722,7 +722,7 @@ configurations:
       difficulty: *expert
       category: *vault
       ctf:
-        enabled: true
+        enabled: false
 
     - name: Challenge 45
       short-name: "challenge-45"
@@ -735,7 +735,7 @@ configurations:
       difficulty: *expert
       category: *vault
       ctf:
-        enabled: true
+        enabled: false
 
     - name: Challenge 46
       short-name: "challenge-46"
@@ -748,7 +748,7 @@ configurations:
       difficulty: *expert
       category: *vault
       ctf:
-        enabled: true
+        enabled: false
 
     - name: Challenge 47
       short-name: "challenge-47"
@@ -761,7 +761,7 @@ configurations:
       difficulty: *normal
       category: *vault
       ctf:
-        enabled: true
+        enabled: false
 
     - name: Challenge 48
       short-name: "challenge-48"

--- a/src/test/e2e/cypress/integration/spoilers.cy.js
+++ b/src/test/e2e/cypress/integration/spoilers.cy.js
@@ -17,6 +17,7 @@ describe('Spoiler Tests', () => {
         cy.dataCy(SpoilersPage.SPOILER_ANSWER).should('not.contain', 'Error Decrypting')
         cy.dataCy(SpoilersPage.SPOILER_ANSWER).should('not.contain', 'Error Executing executable')
         cy.dataCy(SpoilersPage.SPOILER_ANSWER).should('not.contain', 'Error reading secret')
+        cy.dataCy(SpoilersPage.SPOILER_ANSWER).should('not.contain', 'Error, please add the dotnet binary to the challenges file.')
       })
     })
   })


### PR DESCRIPTION
… checks

 <!-- Thank you for submitting a pull request to the WrongSecrets app! See what makes a good PR at https://github.com/OWASP/wrongsecrets/blob/master/CONTRIBUTING.md-->

### What kind of changes does this PR include?

-   [x] Fixes or refactors: disables vault challenges and challenge48 in ctf mode
-   [ ] A new challenge
-   [ ] Additional documentation
-   [ ] Something else

#### Description

<!---
Please provide a helpful summary of what change this pull request will introduce.
--->

### Relations

<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
Closes #0000
--->

### References

<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Checklist:

-   [x] All the contributions made are solely the work of me and my co-authors
-   [x] I tested the changes in this PR (if applicable)
-   [ ] I added unit tests to ensure my change works (when change in Java or on front-end code)
-   [x] I added UI tests to ensure my UI changes work (when change in the overall UI, not needed if just adding a challenge)
-   [x] The PR passes pre-commit hooks and automated tests
