### PR TITLE
fix difficulty in mapping for api/challenges for juiceshopcli

### DIFF
--- a/src/main/java/org/owasp/wrongsecrets/challenges/ChallengesCtfController.java
+++ b/src/main/java/org/owasp/wrongsecrets/challenges/ChallengesCtfController.java
@@ -10,6 +10,7 @@ import org.owasp.wrongsecrets.RuntimeEnvironment;
 import org.owasp.wrongsecrets.ScoreCard;
 import org.owasp.wrongsecrets.definitions.ChallengeDefinition;
 import org.owasp.wrongsecrets.definitions.ChallengeDefinitionsConfiguration;
+import org.owasp.wrongsecrets.definitions.Difficulty;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -68,7 +69,7 @@ public class ChallengesCtfController {
               .orElse(disabledChallenge));
       jsonChallenge.put("solved", scoreCard.getChallengeCompleted(definition));
       jsonChallenge.put("disabledEnv", getDisabledEnv(definition));
-      jsonChallenge.put("difficulty", definition.difficulty().difficulty());
+      jsonChallenge.put("difficulty", getDificulty(definition.difficulty()));
       jsonArray.add(jsonChallenge);
     }
     json.put("status", "success");
@@ -76,6 +77,23 @@ public class ChallengesCtfController {
     String result = json.toJSONString();
     log.trace("returning {}", result);
     return result;
+  }
+
+  private int getDificulty(Difficulty difficulty) {
+    switch (difficulty.difficulty()) {
+      case "easy":
+        return 1;
+      case "normal":
+        return 2;
+      case "hard":
+        return 3;
+      case "expert":
+        return 4;
+      case "master":
+        return 5;
+      default:
+        return 0;
+    }
   }
 
   private String getCategory() {


### PR DESCRIPTION
 <!-- Thank you for submitting a pull request to the WrongSecrets app! See what makes a good PR at https://github.com/OWASP/wrongsecrets/blob/master/CONTRIBUTING.md-->

### What kind of changes does this PR include?

-   [x] Fixes or refactors: fixes difficulty mapping for ctfd defs with juiceshop cli
-   [ ] A new challenge
-   [ ] Additional documentation
-   [ ] Something else

#### Description

<!---
Please provide a helpful summary of what change this pull request will introduce.
--->

### Relations

touches https://github.com/OWASP/wrongsecrets-ctf-party/issues/664

### References

<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Checklist:

-   [x] All the contributions made are solely the work of me and my co-authors
-   [x] I tested the changes in this PR (if applicable)
-   [ ] I added unit tests to ensure my change works (when change in Java or on front-end code)
-   [ ] I added UI tests to ensure my UI changes work (when change in the overall UI, not needed if just adding a challenge)
-   [x] The PR passes pre-commit hooks and automated tests
