### PR TITLE
fix: expand coverage to tools within precommit workflow

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,7 @@
         {
             "customType": "regex",
             "fileMatch": ".github/workflows/pre-commit.yml",
-            "depNameTemplate": "OWASP/terraform-docs/terraform-docs",
+            "depNameTemplate": "terraform-docs/terraform-docs",
             "matchStrings": [
                 "TF_DOCS_VERSION=\"(?<currentValue>.*?)\""
             ],

--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,33 @@
     "customManagers": [
         {
             "customType": "regex",
+            "fileMatch": ".github/workflows/pre-commit.yml",
+            "depNameTemplate": "OWASP/terraform-docs/terraform-docs",
+            "matchStrings": [
+                "TF_DOCS_VERSION=\"(?<currentValue>.*?)\""
+            ],
+            "datasourceTemplate": "github-releases"
+        },
+        {
+            "customType": "regex",
+            "fileMatch": ".github/workflows/pre-commit.yml",
+            "depNameTemplate": "aquasecurity/tfsec",
+            "matchStrings": [
+                "TFSEC_VERSION=\"(?<currentValue>.*?)\""
+            ],
+            "datasourceTemplate": "github-releases"
+        },
+        {
+            "customType": "regex",
+            "fileMatch": ".github/workflows/pre-commit.yml",
+            "depNameTemplate": "terraform-linters/tflint",
+            "matchStrings": [
+                "TFLINT_VERSION=\"(?<currentValue>.*?)\""
+            ],
+            "datasourceTemplate": "github-releases"
+        },
+        {
+            "customType": "regex",
             "fileMatch": ".github/scripts/docker-create.sh",
             "depNameTemplate": "OWASP/wrongsecrets-binaries",
             "matchStrings": [


### PR DESCRIPTION
 <!-- Thank you for submitting a pull request to the WrongSecrets app! See what makes a good PR at https://github.com/OWASP/wrongsecrets/blob/master/CONTRIBUTING.md-->

### What kind of changes does this PR include?

-   [x] Fixes or refactors
-   [ ] A new challenge
-   [ ] Additional documentation
-   [ ] Something else

#### Description

Expand coverage to binaries downloaded in pre-commit workflow.

### Checklist:

-   [x] All the contributions made are solely the work of me and my co-authors
-   [x] I tested the changes in this PR (if applicable)
-   [x] I added unit tests to ensure my change works (when change in Java or on front-end code)
-   [x] I added UI tests to ensure my UI changes work (when change in the overall UI, not needed if just adding a challenge)
-   [x] The PR passes pre-commit hooks and automated tests
