### PR TITLE
Replace tfsec with trivy on github workflows and renovate.json

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup trivy
         run: |
           wget https://github.com/aquasecurity/trivy/releases/download/v${{env.TRIVY_VERSION}}/trivy_${{env.TRIVY_VERSION}}_Linux-64bit.deb
-          sudo dpkg -i trivy.deb
+          sudo dpkg -i trivy_${{env.TRIVY_VERSION}}_Linux-64bit.deb
       - name: Pre-commit checks
         uses: pre-commit/action@v3.0.1
       - name: pre-commit-ci-lite

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -56,7 +56,7 @@ jobs:
           mv terraform-docs /usr/local/bin/
       - name: Setup trivy
         run: |
-          curl --output trivy https://github.com/aquasecurity/trivy/releases/download/v${{env.TRIVY_VERSION}}/trivy_{{env.TRIVY_VERSION}}_Linux-64bit.deb
+          curl --output trivy https://github.com/aquasecurity/trivy/releases/download/v${{env.TRIVY_VERSION}}/trivy_${{env.TRIVY_VERSION}}_Linux-64bit.deb
           sudo dpkg -i trivy.deb
       - name: Pre-commit checks
         uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,8 +8,8 @@ on:
 
 env:
   TF_DOCS_VERSION: v0.19.0
-  TFSEC_VERSION: v1.28.11
   TFLINT_VERSION: v0.53.0
+  TRIVY_VERSION: 0.58.0
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -56,7 +56,7 @@ jobs:
           mv terraform-docs /usr/local/bin/
       - name: Setup trivy
         run: |
-          curl --output trivy https://github.com/aquasecurity/trivy/releases/download/v${{env.TRIVY_VERSION}}/trivy_${{env.TRIVY_VERSION}}_Linux-64bit.deb
+          wget https://github.com/aquasecurity/trivy/releases/download/v${{env.TRIVY_VERSION}}/trivy_${{env.TRIVY_VERSION}}_Linux-64bit.deb
           sudo dpkg -i trivy.deb
       - name: Pre-commit checks
         uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -54,11 +54,10 @@ jobs:
           tar -zxvf terraform_docs.tar.gz terraform-docs
           chmod +x terraform-docs
           mv terraform-docs /usr/local/bin/
-      - name: Setup tfsec
+      - name: Setup trivy
         run: |
-          curl --output tfsec https://github.com/aquasecurity/tfsec/releases/download/${{env.TFSEC_VERSION}}/tfsec-linux-amd64
-          chmod +x tfsec
-          mv tfsec /usr/local/bin/
+          curl --output trivy https://github.com/aquasecurity/trivy/releases/download/v${{env.TRIVY_VERSION}}/trivy_{{env.TRIVY_VERSION}}_Linux-64bit.deb
+          sudo dpkg -i trivy.deb
       - name: Pre-commit checks
         uses: pre-commit/action@v3.0.1
       - name: pre-commit-ci-lite

--- a/renovate.json
+++ b/renovate.json
@@ -28,9 +28,9 @@
         {
             "customType": "regex",
             "fileMatch": ".github/workflows/pre-commit.yml",
-            "depNameTemplate": "aquasecurity/tfsec",
+            "depNameTemplate": "aquasecurity/trivy",
             "matchStrings": [
-                "TFSEC_VERSION=\"(?<currentValue>.*?)\""
+                "TRIVY_VERSION=\"(?<currentValue>.*?)\""
             ],
             "datasourceTemplate": "github-releases"
         },


### PR DESCRIPTION
Issue: https://github.com/OWASP/wrongsecrets/issues/1764

 <!-- Thank you for submitting a pull request to the WrongSecrets app! See what makes a good PR at https://github.com/OWASP/wrongsecrets/blob/master/CONTRIBUTING.md-->

### What kind of changes does this PR include?

-   [x] Fixes or refactors
-   [ ] A new challenge
-   [ ] Additional documentation
-   [ ] Something else

#### Description

Update to trivy because tfsec is no longer updated

### Relations

Closes #1764 

### Checklist:

-   [x] All the contributions made are solely the work of me and my co-authors
-   [ ] I tested the changes in this PR (if applicable)
-   [ ] I added unit tests to ensure my change works (when change in Java or on front-end code)
-   [ ] I added UI tests to ensure my UI changes work (when change in the overall UI, not needed if just adding a challenge)
-   [x] The PR passes pre-commit hooks and automated tests
