### PR TITLE
edit: editing hints in challenge47_hint.adoc

### DIFF
--- a/src/main/resources/explanations/challenge47_hint.adoc
+++ b/src/main/resources/explanations/challenge47_hint.adoc
@@ -2,7 +2,7 @@ This challenge can be solved using the following ways:
 
 - Get the data of the sidecar by looking at the files created by Vault Agent sidecar:
   1. Run `kubectl get pods -A` and find secret-challenge-xxx pod name
-  2. Run `kubectl exec secret-challenge-xxx -c secret-challenge -n default -- cat /vault/secrets/challenge46` where `xxx` is the rest of the randomly generated pod name to print the hardcoded value used by the developer.
+  2. Run `kubectl exec secret-challenge-xxx -c secret-challenge -n default -- cat /vault/secrets/challenge47` where `xxx` is the rest of the randomly generated pod name to print the hardcoded value used by the developer.
 
 - Get the data by checking the logs of the Wrongsecrets pod as the export is being sourced:
   1. Run `kubectl get pods -A` and find secret-challenge-xxx pod name


### PR DESCRIPTION
Hi @commjoen ,

I have completed challenge 47. When I looked at the instructions in the challenge, I noticed that there were typo in the first instructions. You can see them in the image below.

<img width="838" alt="image" src="https://github.com/user-attachments/assets/47be6699-a870-4822-809c-4a53d7bd13fa" />

Now, in this PR! I changed the typo. Maybe you can double check my PR to see if there is anything missing.