### PR TITLE
fix: change AWS InstanceType to t3.large

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -88,7 +88,7 @@ module "eks" {
     disk_type       = "gp3"
     disk_throughput = 150
     disk_iops       = 3000
-    instance_types  = ["t3a.large"]
+    instance_types  = ["t3.large"]
 
     iam_role_additional_policies = {
       AmazonEKSWorkerNodePolicy : "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",


### PR DESCRIPTION
Hi @commjoen ,

I created MR! for chaging AWS instance type from **t3a.large** to **t3.large** according to this #1844 issue. Maybe you can double check my MR to see if there is anything missing. 