### PR TITLE
Fixes for Azure deployment: update readme, TF process, and K8s templates

### DIFF
--- a/azure/README.md
+++ b/azure/README.md
@@ -52,15 +52,16 @@ The storage account name should be in the output. Please use that to configure t
 
 1. Set either a new resource group or use an existing resource group in `main.tf` (it defaults to the existing `OWASP-Projects` resource group). Note that you'll need to find/replace references to "data.azurerm_resource_group.default" to "arurerm_resource_group.default" if you want to create a new one.
 2. check whether you have the right project by doing `az account show` (after `az login`). Want to set the project as your default? Use `az account set --subscription <.id here>`.
-3. If not yet enabled, register the required services for the subscription, run:
+3. do `export ARM_SUBSCRIPTION_ID=<.id here>`.
+4. If not yet enabled, register the required services for the subscription, run:
     - `az provider register --namespace Microsoft.ContainerService`
     - `az provider register --namespace Microsoft.KeyVault`
     - `az provider register --namespace Microsoft.ManagedIdentity`
-4. Run `terraform init` (if required, use `tfenv` to select TF 0.14.0 or higher )
-5. Run `terraform plan` to see what will be created (optional).
-6. Run `terraform apply`. Note: the apply will take 5 to 20 minutes depending on the speed of the Azure backplane.
-7. Run `./k8s-vault-azure-start.sh`. Your kubeconfig file will automatically be updated.
-8. (Optional) To make the app available over a load balancer, run `kubectl apply -f ./k8s/lb.yml`, then look for the public IP using `kubectl describe service wrongsecrets-lb`. The app should be available on HTTP port 80 within a few minutes.
+5. Run `terraform init` (if required, use `tfenv` to select TF 0.14.0 or higher )
+6. Run `terraform plan` to see what will be created (optional).
+7. Run `terraform apply`. Note: the apply will take 5 to 20 minutes depending on the speed of the Azure backplane.
+8. Run `./k8s-vault-azure-start.sh`. Your kubeconfig file will automatically be updated.
+9. (Optional) To make the app available over a load balancer, run `kubectl apply -f ./k8s/lb.yml`, then look for the public IP using `kubectl describe service wrongsecrets-lb`. The app should be available on HTTP port 80 within a few minutes.
 
 Your AKS cluster should be visible in your resource group. Want a different region? You can modify `terraform.tfvars` or input it directly using the `region` variable in plan/apply.
 
@@ -94,7 +95,7 @@ When you're done:
 Want to see if the setup still works? You can use terratest to check if the current setup works via automated terratest tests, for this you need to make sure that you have installed terraform and Go version 1.21. Next, you will need to install the modules and set up credentials.
 
 1. Run `go mod download`
-2. Run `az login` and make sure you are on the right subscription. If necessary, use `az account list` and `az account set --subscription <your-subscription-id-here>`.
+2. Run `az login` and make sure you are on the right subscription. If necessary, use `az account list` and `az account set --subscription <your-subscription-id-here>`. and then do `export ARM_SUBSCRIPTION_ID=<.id here>`.
 3. Run `go test -timeout 99999s`. The default timeout is 10 min, which is too short for our purposes. We need to override that.
 
 ## Terraform documentation

--- a/azure/k8s/secret-challenge-vault-deployment.yml.tpl
+++ b/azure/k8s/secret-challenge-vault-deployment.yml.tpl
@@ -1,24 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    vault.hashicorp.com/agent-inject: "true"
-    vault.hashicorp.com/tls-skip-verify: "true"
-    vault.hashicorp.com/namespace: "default"
-    vault.hashicorp.com/log-level: debug
-    vault.hashicorp.com/agent-inject-secret-challenge46: "secret/data/injected"
-    vault.hashicorp.com/agent-inject-template-challenge46: |
-      {{ with secret "/secret/data/injected" }}
-        {{ range $k, $v := .Data.data }}
-          {{ printf "echo %s=%s" $k $v }}
-        {{ end }}
-      {{ end }}
-    vault.hashicorp.com/agent-inject-secret-challenge47: "secret/data/codified"
-    vault.hashicorp.com/agent-inject-template-challenge47: |
-      {{ with secret "secret/data/codified" }}
-          export challenge47secret="isthiswhatweneed?"
-      {{ end }}
-    vault.hashicorp.com/role: "secret-challenge"
   labels:
     app: secret-challenge
     aadpodidbinding: wrongsecrets-pod-id
@@ -38,7 +20,25 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      creationTimestamp: "2020-10-28T20:21:04Z"
+      annotations:
+        vault.hashicorp.com/agent-inject: "true"
+        vault.hashicorp.com/tls-skip-verify: "true"
+        vault.hashicorp.com/namespace: "default"
+        vault.hashicorp.com/log-level: debug
+        vault.hashicorp.com/agent-inject-secret-challenge46: "secret/data/injected"
+        vault.hashicorp.com/agent-inject-template-challenge46: |
+          {{ with secret "/secret/data/injected" }}
+            {{ range $k, $v := .Data.data }}
+              {{ printf "echo %s=%s" $k $v }}
+            {{ end }}
+          {{ end }}
+        vault.hashicorp.com/agent-inject-secret-challenge47: "secret/data/codified"
+        vault.hashicorp.com/agent-inject-template-challenge47: |
+          {{ with secret "secret/data/codified" }}
+              export challenge47secret="isthiswhatweneed?"
+          {{ end }}
+        vault.hashicorp.com/role: "secret-challenge"
+      creationTimestamp: "2024-03-07T10:21:04Z"
       labels:
         app: secret-challenge
         aadpodidbinding: wrongsecrets-pod-id

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -24,8 +24,10 @@ provider "azurerm" {
       recover_soft_deleted_secrets          = false
     }
   }
+  #requieres to export ARM_SUBSCRIPTION_ID=00000000-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  # subscription_id = "00000000-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 
-  skip_provider_registration = true
+  resource_provider_registrations = "none"
 }
 
 data "azurerm_client_config" "current" {}

--- a/azure/versions.tf
+++ b/azure/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.21.0"
+      version = "~> 4.21.1"
     }
     http = {
       source  = "hashicorp/http"


### PR DESCRIPTION
 <!-- Thank you for submitting a pull request to the WrongSecrets app! See what makes a good PR at https://github.com/OWASP/wrongsecrets/blob/master/CONTRIBUTING.md-->

### What kind of changes does this PR include?

-   [x] Fixes or refactors
-   [ ] A new challenge
-   [ ] Additional documentation
-   [ ] Something else

#### Description

There were bugs in the Azure setup as the new TF provider no longer allowed for the old setup. Secondly the k8s template was wrong. Now both have been fixed in this PR.

Note: we do see that the current resource defs on TF are very tight for this setup. it works, but you cannot deploy anything next to the testing setup.

### Relations

<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
Closes #0000
--->

### References

<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Checklist:

-   [x] All the contributions made are solely the work of me and my co-authors
-   [ ] I tested the changes in this PR (if applicable)
-   [ ] I added unit tests to ensure my change works (when change in Java or on front-end code)
-   [ ] I added UI tests to ensure my UI changes work (when change in the overall UI, not needed if just adding a challenge)
-   [x] The PR passes pre-commit hooks and automated tests
