### PR TITLE
updated time-out as clusters might be underprovisioned

### DIFF
--- a/aws/wrongsecrets_aws_test.go
+++ b/aws/wrongsecrets_aws_test.go
@@ -67,11 +67,11 @@ func TestTerraformWrongSecretsAWS(t *testing.T) {
 	http_helper.HttpGetWithCustomValidation(t, main, nil, validateChallengesEnabled)
 
 	// Make an HTTP request to the instance and make sure we get back a 200 OK and don't see expected string. Retries for a while.
-	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge7, nil, 30, 5*time.Second, validateCloudChallengeResponse)
-	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge9, nil, 30, 5*time.Second, validateCloudChallengeResponse)
-	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge10, nil, 30, 5*time.Second, validateCloudChallengeResponse)
-	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge11, nil, 30, 5*time.Second, validateCloudChallengeResponse)
-	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge47, nil, 30, 5*time.Second, validateCloudChallengeResponse)
+	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge7, nil, 30, 8*time.Second, validateCloudChallengeResponse)
+	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge9, nil, 30, 8*time.Second, validateCloudChallengeResponse)
+	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge10, nil, 30, 8*time.Second, validateCloudChallengeResponse)
+	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge11, nil, 30, 8*time.Second, validateCloudChallengeResponse)
+	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge47, nil, 30, 8*time.Second, validateCloudChallengeResponse)
 }
 
 func validateCloudChallengeResponse(statusCode int, body string) bool {

--- a/azure/wrongsecrets_azure_test.go
+++ b/azure/wrongsecrets_azure_test.go
@@ -57,11 +57,11 @@ func TestTerraformWrongSecretsAzure(t *testing.T) {
 	http_helper.HttpGetWithCustomValidation(t, main, nil, validateChallengesEnabled)
 
 	// Make an HTTP request to the instance and make sure we get back a 200 OK and don't see expected string. Retries for a while.
-	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge7, nil, 30, 5*time.Second, validateCloudChallengeResponse)
-	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge9, nil, 30, 5*time.Second, validateCloudChallengeResponse)
-	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge10, nil, 30, 5*time.Second, validateCloudChallengeResponse)
-	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge11, nil, 30, 5*time.Second, validateCloudChallengeResponse)
-	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge47, nil, 30, 5*time.Second, validateCloudChallengeResponse)
+	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge7, nil, 30, 8*time.Second, validateCloudChallengeResponse)
+	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge9, nil, 30, 8*time.Second, validateCloudChallengeResponse)
+	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge10, nil, 30, 8*time.Second, validateCloudChallengeResponse)
+	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge11, nil, 30, 8*time.Second, validateCloudChallengeResponse)
+	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge47, nil, 30, 8*time.Second, validateCloudChallengeResponse)
 }
 
 func validateCloudChallengeResponse(statusCode int, body string) bool {

--- a/gcp/wrongsecrets_gcp_test.go
+++ b/gcp/wrongsecrets_gcp_test.go
@@ -57,11 +57,11 @@ func TestTerraformWrongSecretsGCP(t *testing.T) {
 	http_helper.HttpGetWithCustomValidation(t, main, nil, validateChallengesEnabled)
 
 	// Make an HTTP request to the instance and make sure we get back a 200 OK and don't see expected string. Retries for a while.
-	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge7, nil, 30, 5*time.Second, validateCloudChallengeResponse)
-	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge9, nil, 30, 5*time.Second, validateCloudChallengeResponse)
-	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge10, nil, 30, 5*time.Second, validateCloudChallengeResponse)
-	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge11, nil, 30, 5*time.Second, validateCloudChallengeResponse)
-	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge47, nil, 30, 5*time.Second, validateCloudChallengeResponse)
+	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge7, nil, 30, 8*time.Second, validateCloudChallengeResponse)
+	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge9, nil, 30, 8*time.Second, validateCloudChallengeResponse)
+	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge10, nil, 30, 8*time.Second, validateCloudChallengeResponse)
+	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge11, nil, 30, 8*time.Second, validateCloudChallengeResponse)
+	http_helper.HttpGetWithRetryWithCustomValidation(t, challenge47, nil, 30, 8*time.Second, validateCloudChallengeResponse)
 }
 
 func validateCloudChallengeResponse(statusCode int, body string) bool {


### PR DESCRIPTION
 <!-- Thank you for submitting a pull request to the WrongSecrets app! See what makes a good PR at https://github.com/OWASP/wrongsecrets/blob/master/CONTRIBUTING.md-->

### What kind of changes does this PR include?

-   [x] Fixes or refactors: ensure that tests for infra make it as we have tight time-outs of 5s for some of them (Azure)
-   [ ] A new challenge
-   [ ] Additional documentation
-   [ ] Something else

#### Description

<!---
Please provide a helpful summary of what change this pull request will introduce.
--->

### Relations

<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
Closes #0000
--->

### References

<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Checklist:

-   [x] All the contributions made are solely the work of me and my co-authors
-   [x] I tested the changes in this PR (if applicable)
-   [ ] I added unit tests to ensure my change works (when change in Java or on front-end code)
-   [ ] I added UI tests to ensure my UI changes work (when change in the overall UI, not needed if just adding a challenge)
-   [x] The PR passes pre-commit hooks and automated tests
