### PR TITLE
fix: patch storage class to use standard as default

### DIFF
--- a/gcp/k8s-vault-gcp-ingress-start.sh
+++ b/gcp/k8s-vault-gcp-ingress-start.sh
@@ -18,6 +18,9 @@ export CLUSTER_NAME="$(terraform output -raw kubernetes_cluster_name)"
 
 gcloud container clusters get-credentials --project ${GCP_PROJECT} --zone ${REGION} ${CLUSTER_NAME}
 
+kubectl patch storageclass standard-rwo -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
+kubectl patch storageclass standard -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+
 kubectl get configmaps | grep 'secrets-file' &>/dev/null
 if [ $? == 0 ]; then
   echo "secrets config is already installed"

--- a/gcp/k8s-vault-gcp-start.sh
+++ b/gcp/k8s-vault-gcp-start.sh
@@ -18,6 +18,9 @@ export CLUSTER_NAME="$(terraform output -raw kubernetes_cluster_name)"
 
 gcloud container clusters get-credentials --project ${GCP_PROJECT} --zone ${REGION} ${CLUSTER_NAME}
 
+kubectl patch storageclass standard-rwo -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
+kubectl patch storageclass standard -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+
 echo "Setting up workspace PSA to restricted for default"
 kubectl apply -f ../k8s/workspace-psa.yml
 


### PR DESCRIPTION
 <!-- Thank you for submitting a pull request to the WrongSecrets app! See what makes a good PR at https://github.com/OWASP/wrongsecrets/blob/master/CONTRIBUTING.md-->

### What kind of changes does this PR include?

-   [x] Fixes or refactors
-   [ ] A new challenge
-   [ ] Additional documentation
-   [ ] Something else

#### Description
Fix GKE setup by using a different standard storage class.

### Checklist:

-   [x] All the contributions made are solely the work of me and my co-authors
-   [x] I tested the changes in this PR (if applicable)
-   [ ] I added unit tests to ensure my change works (when change in Java or on front-end code)
-   [ ] I added UI tests to ensure my UI changes work (when change in the overall UI, not needed if just adding a challenge)
-   [x] The PR passes pre-commit hooks and automated tests
