### PR TITLE
Nety fix for GCP: prevent segfault when running on GCP with cloud challenges

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bellsoft/liberica-openjre-debian:23.0.1-13-cds AS builder
+FROM bellsoft/liberica-openjre-debian:23.0.2-9-cds AS builder
 WORKDIR /builder
 
 ARG argBasedVersion="1.10.3"
@@ -6,7 +6,7 @@ ARG argBasedVersion="1.10.3"
 COPY --chown=wrongsecrets target/wrongsecrets-${argBasedVersion}-SNAPSHOT.jar application.jar
 RUN java -Djarmode=tools -jar application.jar extract --layers --destination extracted
 
-FROM eclipse-temurin:23.0.1_11-jre-alpine
+FROM eclipse-temurin:23.0.2_7-jre-alpine-3.21
 WORKDIR /application
 
 ARG argBasedPassword="default"

--- a/gcp/.terraform.lock.hcl
+++ b/gcp/.terraform.lock.hcl
@@ -65,6 +65,7 @@ provider "registry.terraform.io/hashicorp/http" {
   version     = "3.4.5"
   constraints = "~> 3.4.0"
   hashes = [
+    "h1:ZDXm3QR3UhjciYS49A+KrjVg1qDQ23HyQ24JFdWQEKk=",
     "h1:eSVCYfvn5JyV3LC0+mrLlLtgLv4B+RWeNqz02miBcMY=",
     "zh:2072006c177efc101471f3d5eb8e1d8e6c68778cbfd6db3d3f22f59cfe6ce6ae",
     "zh:3ac4cc0efe11ee054300769cfcc37491433937a8824621d1f8f7a18e7401da87",

--- a/gcp/k8s/secret-challenge-vault-deployment.yml.tpl
+++ b/gcp/k8s/secret-challenge-vault-deployment.yml.tpl
@@ -58,7 +58,7 @@ spec:
             volumeAttributes:
               secretProviderClass: "wrongsecrets-gcp-secretsmanager"
       containers:
-        - image: jeroenwillemsen/wrongsecrets:1.10.3-k8s-vault
+        - image: jeroenwillemsen/wrongsecrets:1.11.0-alpha3-k8s-vault
           imagePullPolicy: IfNotPresent
           name: secret-challenge
           command: ["/bin/sh"]

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <dependency-check-maven.version>12.1.0</dependency-check-maven.version>
     <gatling-maven-plugin.version>4.16.1</gatling-maven-plugin.version>
     <gatling.version>3.13.4</gatling.version>
-    <gcp.sdk.version>6.0.1</gcp.sdk.version>
+    <gcp.sdk.version>5.6.1</gcp.sdk.version>
     <github.button.version>2.14.1</github.button.version>
     <java.version>23</java.version>
     <jquery.version>3.7.1</jquery.version>


### PR DESCRIPTION
 <!-- Thank you for submitting a pull request to the WrongSecrets app! See what makes a good PR at https://github.com/OWASP/wrongsecrets/blob/master/CONTRIBUTING.md-->

### What kind of changes does this PR include?

-   [x] Fixes or refactors: fixes segfault in gcp, works in aws and azure
-   [ ] A new challenge
-   [ ] Additional documentation
-   [ ] Something else

#### Description

<!---
Please provide a helpful summary of what change this pull request will introduce.
--->

### Relations

<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
Closes #0000
--->

### References

<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Checklist:

-   [x] All the contributions made are solely the work of me and my co-authors
-   [x] I tested the changes in this PR (if applicable)
-   [ ] I added unit tests to ensure my change works (when change in Java or on front-end code)
-   [ ] I added UI tests to ensure my UI changes work (when change in the overall UI, not needed if just adding a challenge)
-   [x] The PR passes pre-commit hooks and automated tests
