### PR TITLE
fix: performance issue with Thymeleaf

### DIFF
--- a/src/main/java/org/owasp/wrongsecrets/asciidoc/PreCompiledGenerator.java
+++ b/src/main/java/org/owasp/wrongsecrets/asciidoc/PreCompiledGenerator.java
@@ -1,9 +1,10 @@
 package org.owasp.wrongsecrets.asciidoc;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.tomcat.util.http.fileupload.ByteArrayOutputStream;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.util.FileCopyUtils;
 
@@ -20,7 +21,7 @@ public class PreCompiledGenerator implements TemplateGenerator {
 
     try (var bos = new ByteArrayOutputStream()) {
       FileCopyUtils.copy(new ClassPathResource(templateFile).getInputStream(), bos);
-      return new String(bos.toByteArray(), StandardCharsets.UTF_8);
+      return bos.toString(UTF_8);
     }
   }
 }

--- a/src/main/java/org/owasp/wrongsecrets/challenges/ChallengeUI.java
+++ b/src/main/java/org/owasp/wrongsecrets/challenges/ChallengeUI.java
@@ -69,8 +69,12 @@ public class ChallengeUI {
    *
    * @return the html friendly shortName name for the challenge
    */
+  public String getLink(ChallengeDefinition definition) {
+    return definition.name().shortName();
+  }
+
   public String getLink() {
-    return challengeDefinition.name().shortName();
+    return getLink(this.challengeDefinition);
   }
 
   /**
@@ -88,16 +92,16 @@ public class ChallengeUI {
    * @return int with next challenge number.
    */
   public String next() {
-    return navigation.next().map(c -> c.name().shortName()).orElse(null);
+    return navigation.next().map(this::getLink).orElse(null);
   }
 
   /**
-   * Returns the number of the previous challenge.
+   * Returns the short name of the previous challenge.
    *
    * @return int with previous challenge number.
    */
   public String previous() {
-    return navigation.previous().map(c -> c.name().shortName()).orElse(null);
+    return navigation.previous().map(this::getLink).orElse(null);
   }
 
   private String documentation(Function<ChallengeSource, String> extractor) {

--- a/src/main/resources/templates/challenge.html
+++ b/src/main/resources/templates/challenge.html
@@ -21,7 +21,7 @@
              th:text="${answerCorrect}" th:attr="data-cy='success-alert'"></div>
         <div class="col-12 feedback alert alert-danger" role="alert" th:if="${answerIncorrect!=null}"
              th:text="${answerIncorrect}" th:attr="data-cy='incorrect-alert'"></div>
-        <form action="#" th:action="'/challenge/'+${challenge.link}" th:object="${challengeForm}" method="post">
+        <form action="#" th:action="${challenge.link}" th:object="${challengeForm}" method="post">
             <div class="d-inline">
                 Answer to solution : <input type="text" id="answerfield" th:field="*{solution}"
                                             th:attr="data-cy='answer-textbox'"/>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -18,7 +18,6 @@
                         <a th:class="'nav-link '+${requestURI == '/' ? 'active' : ''}"
                            href="/">Home</a>
                     </li>
-                    </li>
                     <li class="nav-item dropdown">
                         <a th:class="'nav-link dropdown-toggle '+${requestURI.contains('challenge') ? 'active' : ''}"
                            href="#" id="navbarDropdown" role="button"
@@ -28,9 +27,9 @@
                         <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
                             <!--/*@thymesVar id="challenges" type="java.util.List<org.owasp.wrongsecrets.challenges.ChallengeUI>"*/-->
                             <span th:each="challenge : ${challenges}" th:remove="tag">
-                                    <a class="dropdown-item" th:href="@{/challenge} + '/' + ${challenge.link}"><span
-                                        th:text="${challenge.name}" th:remove="tag"></span></a>
-                                </span>
+                                <a class="dropdown-item" th:href="${challenge.link}"><span
+                                    th:text="${challenge.name}" th:remove="tag"></span></a>
+                            </span>
                         </ul>
                     </li>
                     <li class="nav-item">

--- a/src/main/resources/templates/fragments/navigation.html
+++ b/src/main/resources/templates/fragments/navigation.html
@@ -1,15 +1,18 @@
 <!DOCTYPE html>
 <html>
 <body>
+<!--/*@thymesVar id="challenge" type="org.owasp.wrongsecrets.challenges.ChallengeUI"*/-->
 <div class="row" th:fragment="navigation">
     <div class="col-2 text-center">
-        <a th:class="${challenge.previous()} == null ? 'disabled' : ''" th:href="@{/challenge/} + ${challenge.previous()}">Previous</a>
+        <a th:class="${challenge.previous()} == null ? 'disabled' : ''"
+           th:href="${challenge.previous()}">Previous</a>
     </div>
     <div class="offset-2 col-4 text-center">
         <a href="/">Go the main page</a>
     </div>
     <div class="offset-2 col-2 text-center">
-        <a th:class="(${challenge.next()} == null) ? 'disabled' : ''" th:href="@{/challenge/} + ${challenge.next()}">Next</a>
+        <a th:class="${challenge.next()} == null ? 'disabled' : ''"
+           th:href="${challenge.next()}">Next</a>
     </div>
 </div>
 </body>


### PR DESCRIPTION
The loop in header.html to generate all links to all lessons in the dropdown is a performance hit.

Traced it back to `@{/challenge/}` trying to build a link in `StandardLinkBuilder` which results in Spring resolving an url path, resulting in eventually calling CachingResourceResolver#resolveUrlPathInternal which returns null as `@{challenge/}` is not a valid url.

This a lot of time, as far as I can tell the syntax in Thymeleaf for building a link did not change. Since we already have the link in `ChallengeUI` we can simply avoid the concatenation and `@{/challenge/}` usage.

This solves the performance problem at hand, results go from 32 request/sec back to around 445 request/sec.
