### PR TITLE
fix: Azure SDK warning about Netty mismatch.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
     <gatling.version>3.13.5</gatling.version>
     <gcp.sdk.version>5.6.1</gcp.sdk.version>
     <github.button.version>2.14.1</github.button.version>
+    <io.netty.version>4.1.115.Final</io.netty.version>
     <java.version>23</java.version>
     <jquery.version>3.7.1</jquery.version>
     <jruby.version>9.4.9.0</jruby.version>
@@ -96,6 +97,14 @@
         <groupId>com.azure.spring</groupId>
         <artifactId>spring-cloud-azure-dependencies</artifactId>
         <version>${com.azure.spring.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${io.netty.version}</version>
+        <!-- Explicitly define the Netty version to be in sync with the Azure one otherwise a warning is shown -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
This warning triggers if there is a mismatch. You can check this in the class `NettyUtility#validateNettyVersionsInternal`

Fix is to explicitly set the Netty version in the pom.
