### PR TITLE
fix: align Spring Boot version property and adoption checklist with Java 26 and Boot 4.1.1

### DIFF
--- a/docs/SPRING_BOOT_4_ADOPTION_CHECKLIST.md
+++ b/docs/SPRING_BOOT_4_ADOPTION_CHECKLIST.md
@@ -1,6 +1,6 @@
 # Spring Boot 4 Adoption Checklist (WrongSecrets)
 
-This checklist is tailored to the current `wrongsecrets` codebase (Spring Boot `4.0.3`, Java `25`).
+This checklist is tailored to the current `wrongsecrets` codebase (Spring Boot `4.1.1`, Java `26`).
 
 ## How to use this document
 
@@ -10,8 +10,8 @@ This checklist is tailored to the current `wrongsecrets` codebase (Spring Boot `
 
 ## Current baseline (already in place)
 
-- [x] Spring Boot `4.0.3` is configured in `pom.xml`.
-- [x] Spring Cloud line is aligned (`2025.1.1`).
+- [x] Spring Boot `4.1.1` is configured in `pom.xml`.
+- [x] Spring Cloud line is aligned (`2025.1.3`).
 - [x] `@ConfigurationProperties` is already used in multiple places.
 - [x] Mockito inline-mock-maker warning addressed by passing Mockito as Java agent in Surefire.
 

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <spotbugs-maven.version>4.10.4.0</spotbugs-maven.version>
     <spotbugs.version>4.10.4</spotbugs.version>
     <spotless-maven-plugin.version>3.10.1</spotless-maven-plugin.version>
-    <spring-boot.version>4.0.3</spring-boot.version>
+    <spring-boot.version>4.1.1</spring-boot.version>
     <spring-vault.version>4.1.0</spring-vault.version>
     <spring.cloud-version>2025.1.3</spring.cloud-version>
     <spring.security.version>7.0.6</spring.security.version>


### PR DESCRIPTION
# PR: fix: align Spring Boot version property and adoption checklist with Java 26 and Boot 4.1.1

## Related Issue
Fixes #2651

## Changes Proposed
* **[pom.xml]**: Synchronized `<spring-boot.version>` from `4.0.3` to `4.1.1` to match `spring-boot-starter-parent`.
* **[docs/SPRING_BOOT_4_ADOPTION_CHECKLIST.md]**: Updated baseline versions to accurately reflect the current project state (Spring Boot `4.1.1`, Java `26`, and Spring Cloud `2025.1.3`).

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes.
* [x] Verified POM XML consistency and property alignment
* [x] Verified `./scripts/validate-versions.sh` passes successfully

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
