### PR TITLE
fix: extract maven-dependency-plugin property and synchronize version management docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -315,13 +315,13 @@ Press the **_Reload_** button as shown below and allow the project to Reload.
 
 ![Click the 'Reload' button in the Maven tab.](images/reload-maven-5.2.png)
 
-Further use the **_OWASP WrongSecrets --> Lifecycle --> install_** step to load all the depedencies
+Further use the **_OWASP WrongSecrets --> Lifecycle --> install_** step to load all the dependencies
 
 **NOTE:** Indians and other Asia-Pacific countries users may have to use **VPN** if you encounter this exception `org.owasp.dependencycheck.utils.DownloadFailedException: TLS Connection Reset`.
 
 ### Step 7: Running the Project.
 
-Open the **_WrongSecretsApplication_** by following the path **_main>java>org.owasp.wrongsecrets>WrongSecretApplication_**.
+Open the **_WrongSecretsApplication_** by following the path **_main>java>org.owasp.wrongsecrets>WrongSecretsApplication_**.
 
 ![Click on the 'WrongSecretsApplication' file located at main > java > org.owasp.wrongsecrets > WrongSecretApplication](images/open-application-6.1.png)
 

--- a/README.md
+++ b/README.md
@@ -816,8 +816,8 @@ Here are the steps you have to follow to create your own release of WrongSecrets
 ```sh
    docker buildx create --name mybuilder
    docker buildx use mybuilder
-   docker buildx build --platform linux/amd64,linux/arm64 -t <registry/container-name>:<yourtag>-no-vault --build-arg "argBasedPassword='this is on your command line'" --build-arg "PORT=8081" --build-arg "argBasedVersion=<yourtag>" --build-arg "spring_profile=without-vault" --push
-   docker buildx build --platform linux/amd64,linux/arm64 -t <registry/container-name>:<yourtag>-kubernetes-vault--build-arg "argBasedPassword='this is on your command line'" --build-arg "PORT=8081" --build-arg "argBasedVersion=<yourtag>" --build-arg "spring_profile=kubernetes-vault" --push
+   docker buildx build --platform linux/amd64,linux/arm64 -t <registry/container-name>:<yourtag>-no-vault --build-arg "argBasedPassword='this is on your command line'" --build-arg "PORT=8081" --build-arg "argBasedVersion=<yourtag>" --build-arg "spring_profile=without-vault" --push .
+   docker buildx build --platform linux/amd64,linux/arm64 -t <registry/container-name>:<yourtag>-kubernetes-vault --build-arg "argBasedPassword='this is on your command line'" --build-arg "PORT=8081" --build-arg "argBasedVersion=<yourtag>" --build-arg "spring_profile=kubernetes-vault" --push .
 ```
 
 

--- a/docs/VERSION_MANAGEMENT.md
+++ b/docs/VERSION_MANAGEMENT.md
@@ -70,7 +70,7 @@ The `version-sync-check.yml` workflow:
 
 1. **Update pom.xml version**:
    ```xml
-   <version>1.13.0-SNAPSHOT</version>
+   <version>1.14.0-SNAPSHOT</version>
    ```
 
 2. **Run sync script**:
@@ -86,7 +86,7 @@ The `version-sync-check.yml` workflow:
 4. **Commit all changes**:
    ```bash
    git add pom.xml Dockerfile Dockerfile.web
-   git commit -m "Bump version to 1.13.0"
+   git commit -m "Bump version to 1.14.0"
    ```
 
 ## Workflow Integration
@@ -189,8 +189,8 @@ docker run --rm wrongsecrets:ci-test ls -la /tmp/wrongsecrets-*.jar
 
 ```bash
 # Run this script to verify everything is synchronized
-./scripts/check-version-sync.sh 2>/dev/null || {
-  echo "Version sync check script not found, running manual check:"
+./scripts/validate-versions.sh 2>/dev/null || {
+  echo "Version validation script failed or not found, running manual check:"
   MAVEN_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
   echo "Maven version: $MAVEN_VERSION"
   echo "Checking Dockerfiles for hard-coded versions..."

--- a/pom.xml
+++ b/pom.xml
@@ -63,13 +63,14 @@
     <gatling.version>3.15.1</gatling.version>
     <github.button.version>2.14.1</github.button.version>
     <google.cloud.libraries-bom.version>26.87.0</google.cloud.libraries-bom.version>
-    <!-- Pin Groovy to 4.x for thymeleaf-layout-dialect compatibility (Spring Boot 4.0 manages 5.x) -->
+    <!-- Pin Groovy to 4.x for thymeleaf-layout-dialect compatibility (Spring Boot 4.x manages 5.x) -->
     <groovy.version>4.0.25</groovy.version>
     <java.version>26</java.version>
     <jquery.version>3.7.1</jquery.version>
     <jruby.version>10.1.1.0</jruby.version>
     <lombok.version>1.18.48</lombok.version>
     <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
+    <maven-dependency-plugin.version>3.11.0</maven-dependency-plugin.version>
     <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
     <maven.compiler.proc>full</maven.compiler.proc>
     <maven.compiler.source>26</maven.compiler.source>
@@ -680,7 +681,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.11.0</version>
+        <version>${maven-dependency-plugin.version}</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
### What kind of changes does this PR include?

- [x] Fixes or refactors
- [ ] A new challenge
- [x] Additional documentation
- [ ] Something else

#### Description

This PR addresses POM configuration consistency and documentation inaccuracies:

1. **`pom.xml`**:
   - Extracted `<maven-dependency-plugin.version>3.11.0</maven-dependency-plugin.version>` into `<properties>`, resolving the only plugin in `<build><plugins>` that had a hardcoded version string. This aligns with project POM conventions and allows dependency bots to track and bump it cleanly.
   - Updated the Groovy compatibility comment from `(Spring Boot 4.0 manages 5.x)` to `(Spring Boot 4.x manages 5.x)` to match the current Spring Boot 4.1.1 baseline.

2. **`docs/VERSION_MANAGEMENT.md`**:
   - Replaced references to the non-existent `./scripts/check-version-sync.sh` script with the actual `./scripts/validate-versions.sh` script.
   - Updated outdated `1.13.0` / `1.13.0-SNAPSHOT` example release references to `1.14.0` / `1.14.0-SNAPSHOT`.

3. **`README.md` & `CONTRIBUTING.md`**:
   - Fixed missing space before `--build-arg` and added build context `.` in the custom release Docker buildx command in `README.md`.
   - Corrected typos (`depedencies` and `WrongSecretApplication`) in `CONTRIBUTING.md`.

### Relations

Closes #2661 

### How Has This Been Tested?

- [x] Verified POM XML consistency and property alignment with `./mvnw validate`
- [x] Passed Spotless formatting and Tidy checks (`./mvnw spotless:apply tidy:check`)
- [x] Verified `./scripts/validate-versions.sh` passes successfully with zero mismatches

### Checklist:

- [x] All the contributions made are solely the work of me and my co-authors
- [x] I used AI to generate parts of the content.
- [x] I tested the changes in this PR (if applicable)
- [ ] I added unit tests to ensure my change works (when change in Java or on front-end code)
- [ ] I added UI tests to ensure my UI changes work (when change in the overall UI, not needed if just adding a challenge)
- [x] The PR passes pre-commit hooks and automated tests
